### PR TITLE
BASIRA #58 - Action buttons

### DIFF
--- a/client/src/hooks/ValueListItems.js
+++ b/client/src/hooks/ValueListItems.js
@@ -42,7 +42,7 @@ const withValueList = (WrappedComponent: ComponentType<any>) => (props: Props) =
   const attributes = useMemo(() => ({
     value_list_group: props.group,
     value_list_object: props.object,
-    form_field: props.formField
+    form_field: props.formField || ''
   }), [props.group, props.object, props.formField]);
 
   /**

--- a/client/src/pages/admin/Document.js
+++ b/client/src/pages/admin/Document.js
@@ -6,6 +6,7 @@ import { withRouter } from 'react-router-dom';
 import { Dropdown, Form, Grid } from 'semantic-ui-react';
 import _ from 'underscore';
 import ActionModal from '../../components/ActionModal';
+import Action from '../../transforms/Action';
 import Actions from '../../utils/Actions';
 import DocumentsService from '../../services/Documents';
 import ItemLabel from '../../components/ItemLabel';
@@ -551,6 +552,7 @@ const Document = (props: Props) => {
           modal={{
             component: ActionModal
           }}
+          onCopy={Action.toCopy.bind(this)}
           onDelete={props.onDeleteChildAssociation.bind(this, 'actions')}
           onSave={props.onSaveChildAssociation.bind(this, 'actions')}
         />

--- a/client/src/transforms/Action.js
+++ b/client/src/transforms/Action.js
@@ -1,10 +1,28 @@
 // @flow
 
+import uuid from 'react-uuid';
 import _ from 'underscore';
 
 import type { Action as ActionType } from '../types/Action';
 
 class Action {
+  /**
+   * Returns a copy of the passed action striped of the identifier attributes.
+   *
+   * @param action
+   *
+   * @returns {*&{qualifications}}
+   */
+  toCopy(action: ActionType) {
+    return {
+      ..._.omit(action, 'id', 'uid'),
+      qualifications: _.map(action.qualifications, (qualification) => ({
+        ..._.omit(qualification, 'id', 'uid', '_destroy', 'qualifiable_id'),
+        uid: uuid()
+      }))
+    };
+  }
+
   /**
    * Returns the passed action as a dropdown option.
    *


### PR DESCRIPTION
This pull request fixes a bug that occurred when editing an existing action. The ValueListDropdown component was not correctly resolving the `form_field` prop as an empty string.

This pull request also adds a custom function used to copy an `action` record and related qualifications.