### PR TITLE
BASIRA #66 - Updating the EditPage component to navigate to the URL o…

### DIFF
--- a/client/src/components/SimpleEditPage.js
+++ b/client/src/components/SimpleEditPage.js
@@ -29,6 +29,11 @@ type Props = Translateable & {
   errors: Array<string>,
   history: typeof RouterHistory,
   loading: boolean,
+  location: {
+    state: {
+      saved: boolean
+    }
+  },
   onSave: (item: any) => Promise<any>,
   saving: boolean,
   showLoading?: boolean,
@@ -69,6 +74,12 @@ class SimpleEditPage extends Component<Props, State> {
    */
   componentDidMount() {
     this.onTabClick(_.first(Element.findByType(this.props.children, SimpleEditPage.Tab)));
+
+    const { saved } = this.props.location.state || false;
+
+    if (saved) {
+      this.setState({ showToaster: true });
+    }
   }
 
   /**
@@ -322,7 +333,7 @@ class SimpleEditPage extends Component<Props, State> {
    * @returns {JSX.Element|null}
    */
   renderToaster() {
-    if (!this.state.showToaster) {
+    if (!this.state.showToaster || this.props.saving) {
       return null;
     }
 

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -112,7 +112,8 @@
       "saved": {
         "content": "Your changes have been saved.",
         "header": "Success!"
-      }
+      },
+      "saving": "Saving"
     },
     "tabs": {
       "details": "Details",

--- a/client/src/pages/admin/Artwork.js
+++ b/client/src/pages/admin/Artwork.js
@@ -52,6 +52,7 @@ const Artwork = (props: Props) => {
       errors={props.errors}
       loading={props.loading}
       onSave={props.onSave}
+      saving={props.saving}
       type={props.item.id ? undefined : props.t('Common.labels.artwork')}
     >
       <SimpleEditPage.Header>
@@ -336,7 +337,7 @@ const Artwork = (props: Props) => {
 export default useEditPage(withMenuBar(Artwork), {
   getArtworkId: (item) => item.id,
   onLoad: (id) => ArtworksService.fetchOne(id).then(({ data }) => data.artwork),
-  onSave: (artwork) => ArtworksService.save(artwork),
+  onSave: (artwork) => ArtworksService.save(artwork).then(({ data }) => data.artwork),
   required: ['date_descriptor'],
   validate: (artwork) => {
     let validationErrors = {};

--- a/client/src/pages/admin/Document.js
+++ b/client/src/pages/admin/Document.js
@@ -61,6 +61,7 @@ const Document = (props: Props) => {
       errors={props.errors}
       loading={props.loading}
       onSave={props.onSave}
+      saving={props.saving}
       type={props.item.id ? undefined : props.t('Common.labels.document')}
     >
       <SimpleEditPage.Header>
@@ -562,5 +563,5 @@ const Document = (props: Props) => {
 export default useEditPage(withRouter(withMenuBar(withSingleImage(Document))), {
   getArtworkId: (item) => item.artwork_id,
   onLoad: (id) => DocumentsService.fetchOne(id).then(({ data }) => data.document),
-  onSave: (doc) => DocumentsService.save(doc)
+  onSave: (doc) => DocumentsService.save(doc).then(({ data }) => data.document)
 });

--- a/client/src/pages/admin/EditPage.js
+++ b/client/src/pages/admin/EditPage.js
@@ -2,7 +2,7 @@
 
 import React, { type ComponentType } from 'react';
 import { useEditContainer } from 'react-components';
-import { useParams } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
 import _ from 'underscore';
 
 type Config = {
@@ -14,6 +14,26 @@ type Config = {
 const useEditPage = (WrappedComponent: ComponentType<any>, config: Config) => (
   (props: any) => {
     const { id } = useParams();
+    const history = useHistory();
+
+    const { pathname } = history.location;
+    const url = pathname.substring(0, pathname.lastIndexOf('/'));
+
+    /**
+     * If we're saving a new record, navigate to the new ID.
+     *
+     * @param record
+     */
+    const afterSave = (record) => {
+      if (!id) {
+        history.replace({
+          pathname: `${url}/${record.id}`,
+          state: {
+            saved: true
+          }
+        });
+      }
+    };
 
     const EditPage = (innerProps) => (
       <WrappedComponent
@@ -29,7 +49,7 @@ const useEditPage = (WrappedComponent: ComponentType<any>, config: Config) => (
         {..._.pick(config, 'defaults', 'getArtworkId', 'required', 'validate')}
         item={{ id }}
         onInitialize={config.onLoad}
-        onSave={config.onSave.bind(this)}
+        onSave={(item) => config.onSave(item).then(afterSave)}
       />
     );
   }

--- a/client/src/pages/admin/Person.js
+++ b/client/src/pages/admin/Person.js
@@ -32,6 +32,7 @@ const Person = (props: Props) => (
     errors={props.errors}
     loading={props.loading}
     onSave={props.onSave}
+    saving={props.saving}
   >
     <SimpleEditPage.Tab
       key={Tabs.details}
@@ -130,6 +131,6 @@ const Person = (props: Props) => (
 
 export default useEditPage(withMenuBar(Person), {
   onLoad: (id) => PeopleService.fetchOne(id).then(({ data }) => data.person),
-  onSave: (person) => PeopleService.save(person),
+  onSave: (person) => PeopleService.save(person).then(({ data }) => data.person),
   required: ['name', 'display_name']
 });

--- a/client/src/pages/admin/PhysicalComponent.js
+++ b/client/src/pages/admin/PhysicalComponent.js
@@ -41,6 +41,7 @@ const PhysicalComponent = (props: Props) => {
       errors={props.errors}
       loading={props.loading}
       onSave={props.onSave}
+      saving={props.saving}
       type={props.item.id ? undefined : props.t('Common.labels.physicalComponent')}
     >
       <SimpleEditPage.Header>
@@ -106,5 +107,5 @@ const PhysicalComponent = (props: Props) => {
 export default useEditPage(withRouter(withMenuBar(withSingleImage(PhysicalComponent))), {
   getArtworkId: (item) => item.artwork_id,
   onLoad: (id) => PhysicalComponentsService.fetchOne(id).then(({ data }) => data.physical_component),
-  onSave: (pc) => PhysicalComponentsService.save(pc)
+  onSave: (pc) => PhysicalComponentsService.save(pc).then(({ data }) => data.physical_component)
 });

--- a/client/src/pages/admin/Place.js
+++ b/client/src/pages/admin/Place.js
@@ -32,6 +32,7 @@ const Place = (props: Props) => (
     errors={props.errors}
     loading={props.loading}
     onSave={props.onSave}
+    saving={props.saving}
   >
     <SimpleEditPage.Tab
       key={Tabs.details}
@@ -129,6 +130,6 @@ const Place = (props: Props) => (
 
 export default withTranslation()(useEditPage(withMenuBar(Place), {
   onLoad: (id) => PlacesService.fetchOne(id).then(({ data }) => data.place),
-  onSave: (place) => PlacesService.save(place),
+  onSave: (place) => PlacesService.save(place).then(({ data }) => data.place),
   required: ['name']
 }));

--- a/client/src/pages/admin/VisualContext.js
+++ b/client/src/pages/admin/VisualContext.js
@@ -44,6 +44,7 @@ const VisualContext = (props: Props) => {
       errors={props.errors}
       loading={props.loading}
       onSave={props.onSave}
+      saving={props.saving}
       type={props.item.id ? undefined : props.t('Common.labels.visualContext')}
     >
       <SimpleEditPage.Header>
@@ -148,5 +149,5 @@ const VisualContext = (props: Props) => {
 export default useEditPage(withRouter(withMenuBar(withSingleImage(VisualContext))), {
   getArtworkId: (item) => item.artwork_id,
   onLoad: (id) => VisualContextsService.fetchOne(id).then(({ data }) => data.visual_context),
-  onSave: (pc) => VisualContextsService.save(pc)
+  onSave: (pc) => VisualContextsService.save(pc).then(({ data }) => data.visual_context)
 });


### PR DESCRIPTION
This pull request fixes a bug where the URL was not being updated correctly after saving a record. The application would remain at `/artworks/new`, for example. This could cause each click of the "Save" button to create a new record. 

The fix was to navigate to the URL of the newly created record (`/artworks/387`, for example) after saving the record for the first time.

This pull request also closes #69 and #70.

**Note:** This pull request also has a dependent [PR](https://github.com/performant-software/react-components/pull/91) in the react-components repo.