### PR TITLE
BASIRA #85 - Artwork sidebar

### DIFF
--- a/client/src/hooks/MenuBar.js
+++ b/client/src/hooks/MenuBar.js
@@ -2,6 +2,7 @@
 
 import React, {
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ComponentType
@@ -29,6 +30,21 @@ const withMenuBar = (WrappedComponent: ComponentType<any>) => withTranslation()(
   const [sidebarHeight, setSidebarHeight] = useState(0);
   const [sidebarVisible, setSidebarVisible] = useState(false);
 
+  /**
+   * Returns the ID for the currently selected artwork.
+   *
+   * @type {*}
+   */
+  const artworkId = useMemo(() => {
+    let id;
+
+    if (props.getArtworkId && props.item) {
+      id = props.getArtworkId(props.item);
+    }
+
+    return id;
+  }, [props.getArtworkId, props.item]);
+
   useEffect(() => {
     const menuBarInstance = menuBarRef.current;
 
@@ -53,7 +69,7 @@ const withMenuBar = (WrappedComponent: ComponentType<any>) => withTranslation()(
             secondary
           >
             <Menu.Item>
-              { props.getArtworkId && (
+              { artworkId && (
                 <Button
                   basic
                   icon='bars'
@@ -139,7 +155,7 @@ const withMenuBar = (WrappedComponent: ComponentType<any>) => withTranslation()(
           minHeight: sidebarHeight
         }}
       >
-        { props.getArtworkId && (
+        { artworkId && (
           <Sidebar
             as={Segment}
             animation='overlay'
@@ -152,7 +168,7 @@ const withMenuBar = (WrappedComponent: ComponentType<any>) => withTranslation()(
             }}
           >
             <AccordionMenu
-              id={props.getArtworkId(props.item)}
+              id={artworkId}
             />
           </Sidebar>
         )}


### PR DESCRIPTION
This pull request fixes a UI issue with the sidebar when creating a new artwork record. When opening the sidebar, the loading spinner would persist indefinitely. This was because there was not yet an artwork record to load the tree structure.

The solution was simple to hide the sidebar icon until the artwork record is saved.

## Creating a new artwork
![Screen Shot 2021-07-22 at 2 59 09 PM](https://user-images.githubusercontent.com/20641961/126694986-6c7e91cc-1d92-474f-9bc1-805f1b96b67c.png)

## After save
After saving the record, the sidebar icon will display and the menu will load correctly.
![Screen Shot 2021-07-22 at 2 59 17 PM](https://user-images.githubusercontent.com/20641961/126694989-f109fad6-dcb2-4dbb-8f3a-3804a2ccd2f7.png)
![Screen Shot 2021-07-22 at 2 59 22 PM](https://user-images.githubusercontent.com/20641961/126694991-0a16111a-fc33-40e6-a500-5c72c2079d22.png)
