### PR TITLE
BASIRA #64 - Publish/Notes buttons

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -324,6 +324,16 @@
     "buttons": {
       "remove": "Remove",
       "upload": "Upload"
+    },
+    "popups": {
+      "notes": {
+        "content": "Add or remove internal notes",
+        "header": "Notes"
+      },
+      "publish": {
+        "content": "Toggle the published indicator on/off",
+        "header": "Publish"
+      }
     }
   },
   "SimpleEditPage": {


### PR DESCRIPTION
This pull request adds the resource strings for the publish and notes buttons on the artworks edit page.

![Screen Shot 2021-07-23 at 8 44 15 AM](https://user-images.githubusercontent.com/20641961/126783425-988082cd-316b-43ab-ab51-3e6a21594d8b.png)
![Screen Shot 2021-07-23 at 8 44 20 AM](https://user-images.githubusercontent.com/20641961/126783426-d6518c48-58fe-430d-8600-b8b009d03b4d.png)
