### PR TITLE
BASIRA #97 - Duplicate actions

### DIFF
--- a/client/src/components/SimpleEditPage.js
+++ b/client/src/components/SimpleEditPage.js
@@ -31,10 +31,12 @@ type Props = Translateable & {
   loading: boolean,
   location: {
     state: {
-      saved: boolean
+      saved: boolean,
+      tab?: string
     }
   },
   onSave: (item: any) => Promise<any>,
+  onTabClick?: (tab: string) => void,
   saving: boolean,
   showLoading?: boolean,
   stickyMenu?: boolean,
@@ -70,13 +72,22 @@ class SimpleEditPage extends Component<Props, State> {
   }
 
   /**
-   * Selects the first tab.
+   * Sets up the component on mount.
    */
   componentDidMount() {
-    this.onTabClick(_.first(Element.findByType(this.props.children, SimpleEditPage.Tab)));
+    const { state = {} } = this.props.location;
+    const { saved, tab } = state;
 
-    const { saved } = this.props.location.state || false;
+    const tabs = Element.findByType(this.props.children, SimpleEditPage.Tab);
 
+    // If a tab if provided by the router state, set the tab. Otherwise default to the first tab.
+    if (tab) {
+      this.onTabClick(_.findWhere(tabs, { key: tab }));
+    } else {
+      this.onTabClick(_.first(tabs));
+    }
+
+    // If the record has been saved, display the toaster.
     if (saved) {
       this.setState({ showToaster: true });
     }
@@ -103,7 +114,11 @@ class SimpleEditPage extends Component<Props, State> {
    * @param tab
    */
   onTabClick(tab) {
-    this.setState({ tab: tab.key });
+    this.setState({ tab: tab.key }, () => {
+      if (this.props.onTabClick) {
+        this.props.onTabClick(tab.key);
+      }
+    });
   }
 
   /**

--- a/client/src/pages/admin/Artwork.js
+++ b/client/src/pages/admin/Artwork.js
@@ -22,11 +22,11 @@ import ValueListDropdown from '../../components/ValueListDropdown';
 import useEditPage from './EditPage';
 import withMenuBar from '../../hooks/MenuBar';
 
-import type { EditContainerProps } from 'react-components/types';
 import type { Artwork as ArtworkType } from '../../types/Artwork';
+import type { EditPageProps } from './EditPage';
 import type { Translateable } from '../../types/Translateable';
 
-type Props = EditContainerProps & Translateable & {
+type Props = EditPageProps & Translateable & {
   item: ArtworkType
 };
 
@@ -57,6 +57,7 @@ const Artwork = (props: Props) => {
       errors={props.errors}
       loading={props.loading}
       onSave={props.onSave}
+      onTabClick={props.onTabClick}
       saving={props.saving}
       type={props.item.id ? undefined : props.t('Common.labels.artwork')}
     >

--- a/client/src/pages/admin/Document.js
+++ b/client/src/pages/admin/Document.js
@@ -20,13 +20,13 @@ import withMenuBar from '../../hooks/MenuBar';
 import withSingleImage from '../../hooks/Image';
 import './Document.css';
 
-import type { EditContainerProps } from 'react-components/types';
+import type { EditPageProps } from './EditPage';
 import type { ImageProps } from '../../hooks/Image';
 import type { Document as DocumentType } from '../../types/Document';
 import type { Translateable } from '../../types/Translateable';
 import type { Routeable } from '../../types/Routeable';
 
-type Props = EditContainerProps & ImageProps & Routeable & Translateable & {
+type Props = EditPageProps & ImageProps & Routeable & Translateable & {
   item: DocumentType
 };
 
@@ -65,6 +65,7 @@ const Document = (props: Props) => {
       errors={props.errors}
       loading={props.loading}
       onSave={props.onSave}
+      onTabClick={props.onTabClick}
       saving={props.saving}
       type={props.item.id ? undefined : props.t('Common.labels.document')}
     >

--- a/client/src/pages/admin/EditPage.js
+++ b/client/src/pages/admin/EditPage.js
@@ -5,6 +5,8 @@ import { useEditContainer } from 'react-components';
 import { useHistory, useParams } from 'react-router-dom';
 import _ from 'underscore';
 
+import type { EditContainerProps } from 'react-components/types';
+
 type Config = {
   onLoad: (params: any) => Promise<any>,
   onSave: (item: any) => Promise<any>,
@@ -19,25 +21,30 @@ const useEditPage = (WrappedComponent: ComponentType<any>, config: Config) => (
     const { pathname } = history.location;
     const url = pathname.substring(0, pathname.lastIndexOf('/'));
 
+    let tab;
+
     /**
-     * If we're saving a new record, navigate to the new ID.
+     * Navigate to the new URL to force the component to be re-mounted. This ensures that the IDs of new records
+     * are appropriately updated.
      *
      * @param record
      */
     const afterSave = (record) => {
-      if (!id) {
-        history.replace({
-          pathname: `${url}/${record.id}`,
-          state: {
-            saved: true
-          }
-        });
-      }
+      history.replace({
+        pathname: `${url}/${record.id}`,
+        state: {
+          saved: true,
+          tab
+        }
+      });
     };
 
     const EditPage = (innerProps) => (
       <WrappedComponent
         {...innerProps}
+        onTabClick={(t) => {
+          tab = t;
+        }}
       />
     );
 
@@ -56,3 +63,8 @@ const useEditPage = (WrappedComponent: ComponentType<any>, config: Config) => (
 );
 
 export default useEditPage;
+
+export type EditPageProps = {
+  ...EditContainerProps,
+  onTabClick: (tab: string) => void
+};

--- a/client/src/pages/admin/Person.js
+++ b/client/src/pages/admin/Person.js
@@ -13,11 +13,11 @@ import SimpleLink from '../../components/SimpleLink';
 import withMenuBar from '../../hooks/MenuBar';
 import useEditPage from './EditPage';
 
-import type { EditContainerProps } from 'react-components/types';
+import type { EditPageProps } from './EditPage';
 import type { Person as PersonType } from '../../types/Person';
 import type { Translateable } from '../../types/Translateable';
 
-type Props = EditContainerProps & Translateable & {
+type Props = EditPageProps & Translateable & {
   item: PersonType
 };
 
@@ -32,6 +32,7 @@ const Person = (props: Props) => (
     errors={props.errors}
     loading={props.loading}
     onSave={props.onSave}
+    onTabClick={props.onTabClick}
     saving={props.saving}
   >
     <SimpleEditPage.Tab

--- a/client/src/pages/admin/PhysicalComponent.js
+++ b/client/src/pages/admin/PhysicalComponent.js
@@ -12,13 +12,13 @@ import Validations from '../../utils/Validations';
 import withMenuBar from '../../hooks/MenuBar';
 import withSingleImage from '../../hooks/Image';
 
-import type { EditContainerProps } from 'react-components/types';
+import type { EditPageProps } from './EditPage';
 import type { ImageProps } from '../../hooks/Image';
 import type { PhysicalComponent as PhysicalComponentType } from '../../types/PhysicalComponent';
 import type { Translateable } from '../../types/Translateable';
 import type { Routeable } from '../../types/Routeable';
 
-type Props = EditContainerProps & ImageProps & Routeable & Translateable & {
+type Props = EditPageProps & ImageProps & Routeable & Translateable & {
   item: PhysicalComponentType
 };
 
@@ -42,6 +42,7 @@ const PhysicalComponent = (props: Props) => {
       errors={props.errors}
       loading={props.loading}
       onSave={props.onSave}
+      onTabClick={props.onTabClick}
       saving={props.saving}
       type={props.item.id ? undefined : props.t('Common.labels.physicalComponent')}
     >

--- a/client/src/pages/admin/Place.js
+++ b/client/src/pages/admin/Place.js
@@ -13,11 +13,11 @@ import SimpleLink from '../../components/SimpleLink';
 import useEditPage from './EditPage';
 import withMenuBar from '../../hooks/MenuBar';
 
-import type { EditContainerProps } from 'react-components/types';
+import type { EditPageProps } from './EditPage';
 import type { Place as PlaceType } from '../../types/Place';
 import type { Translateable } from '../../types/Translateable';
 
-type Props = EditContainerProps & Translateable & {
+type Props = EditPageProps & Translateable & {
   item: PlaceType
 };
 
@@ -32,6 +32,7 @@ const Place = (props: Props) => (
     errors={props.errors}
     loading={props.loading}
     onSave={props.onSave}
+    onTabClick={props.onTabClick}
     saving={props.saving}
   >
     <SimpleEditPage.Tab

--- a/client/src/pages/admin/VisualContext.js
+++ b/client/src/pages/admin/VisualContext.js
@@ -13,13 +13,13 @@ import VisualContextsService from '../../services/VisualContexts';
 import withMenuBar from '../../hooks/MenuBar';
 import withSingleImage from '../../hooks/Image';
 
-import type { EditContainerProps } from 'react-components/types';
+import type { EditPageProps } from './EditPage';
 import type { ImageProps } from '../../hooks/Image';
 import type { VisualContext as VisualContextType } from '../../types/VisualContext';
 import type { Translateable } from '../../types/Translateable';
 import type { Routeable } from '../../types/Routeable';
 
-type Props = EditContainerProps & ImageProps & Routeable & Translateable & {
+type Props = EditPageProps & ImageProps & Routeable & Translateable & {
   item: VisualContextType
 };
 
@@ -48,6 +48,7 @@ const VisualContext = (props: Props) => {
       errors={props.errors}
       loading={props.loading}
       onSave={props.onSave}
+      onTabClick={props.onTabClick}
       saving={props.saving}
       type={props.item.id ? undefined : props.t('Common.labels.visualContext')}
     >


### PR DESCRIPTION
This pull request fixes a bug that occurred when saving a record. We were correctly sending the `POST` request to the API and persisting the data to the database. However, after the successful API request, the record was not updated on the client side to reflect the IDs of any newly created records. This lead to duplicates being created if the record was saved multiple times on initial creation without the page being refreshed.

The solution is to always re-mount the edit page component in order to correctly update the ID values of the main record being edited, as well as any related child records.