### PR TITLE
BASIRA #102 - Add People date columns

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -11,7 +11,8 @@ class Person < ApplicationRecord
 
   # Resourceable parameters
   allow_params :name, :display_name, :person_type, :nationality, :authorized_vocabulary, :url, :database_value,
-               :comment, :part_of, :same_as,
+               :comment, :part_of, :same_as, :artist_birth_date,
+               :artist_death_date, :years_active,
                participations_attributes: [:id, :participateable_id, :participateable_type,
                                            :role, :subrole, :description, :certainty, :notes, :_destroy]
 end

--- a/app/serializers/people_serializer.rb
+++ b/app/serializers/people_serializer.rb
@@ -4,5 +4,5 @@ class PeopleSerializer < BaseSerializer
 
   index_attributes :id, :name, :display_name, :person_type, :nationality
   show_attributes :id, :name, :display_name, :person_type, :nationality, :authorized_vocabulary, :url, :database_value,
-                  :comment, :part_of, :same_as, participations: ParticipationsSerializer
+                  :comment, :part_of, :same_as, :artist_birth_date, :artist_death_date, :years_active,  participations: ParticipationsSerializer
 end

--- a/app/services/airtable_importer/models/person.rb
+++ b/app/services/airtable_importer/models/person.rb
@@ -23,6 +23,12 @@ module AirtableImporter
             person = ::Person.find_by(airtable_id: airtable_id)
             ::Participation.find_or_initialize_by(person: person, participateable: artwork)
           end
+         }, {
+           attribute_name: :artist_birth_date,
+           airtable_name: 'Artist_Born'
+         }, {
+           attribute_name: :artist_death_date,
+           airtable_name: 'Artist_Death_Date'
          }]
       end
 

--- a/client/src/components/PersonForm.js
+++ b/client/src/components/PersonForm.js
@@ -47,6 +47,27 @@ const PersonForm = (props: Props) => (
       value={props.item.nationality || ''}
     />
     <Form.Input
+      error={props.isError('artist_birth_date')}
+      label={props.t('Person.labels.yearOfBirth')}
+      onChange={props.onTextInputChange.bind(this, 'artist_birth_date')}
+      required={props.isRequired('artist_birth_date')}
+      value={props.item.artist_birth_date || ''}
+    />
+    <Form.Input
+      error={props.isError('artist_death_date')}
+      label={props.t('Person.labels.yearOfDeath')}
+      onChange={props.onTextInputChange.bind(this, 'artist_death_date')}
+      required={props.isRequired('artist_death_date')}
+      value={props.item.artist_death_date || ''}
+    />
+    <Form.Input
+      error={props.isError('years_active')}
+      label={props.t('Person.labels.yearsOfActivity')}
+      onChange={props.onTextInputChange.bind(this, 'years_active')}
+      required={props.isRequired('years_active')}
+      value={props.item.years_active || ''}
+    />
+    <Form.Input
       error={props.isError('authorized_vocabulary')}
       label={props.t('Person.labels.authorizedVocabulary')}
       onChange={props.onTextInputChange.bind(this, 'authorized_vocabulary')}

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -274,7 +274,10 @@
       "name": "Name",
       "nationality": "Nationality",
       "type": "Type",
-      "url": "URL"
+      "url": "URL",
+      "yearOfBirth": "Year of birth",
+      "yearOfDeath": "Year of death",
+      "yearsOfActivity": "Years of activity"
     },
     "locations": {
       "columns": {

--- a/client/src/transforms/Person.js
+++ b/client/src/transforms/Person.js
@@ -19,6 +19,8 @@ class Person extends BaseTransform {
   getPayloadKeys() {
     return [
       'name',
+      'artist_birth_date',
+      'artist_death_date',
       'display_name',
       'person_type',
       'nationality',
@@ -27,7 +29,8 @@ class Person extends BaseTransform {
       'database_value',
       'comment',
       'part_of',
-      'same_as'
+      'same_as',
+      'years_active'
     ];
   }
 

--- a/db/migrate/20210730065408_add_people_dates_to_people.rb
+++ b/db/migrate/20210730065408_add_people_dates_to_people.rb
@@ -1,0 +1,7 @@
+class AddPeopleDatesToPeople < ActiveRecord::Migration[6.0]
+  def change
+    add_column :people, :artist_birth_date, :string
+    add_column :people, :artist_death_date, :string
+    add_column :people, :years_active, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_23_115502) do
+ActiveRecord::Schema.define(version: 2021_07_30_065408) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -158,6 +158,9 @@ ActiveRecord::Schema.define(version: 2021_07_23_115502) do
     t.datetime "airtable_timestamp"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "artist_birth_date"
+    t.string "artist_death_date"
+    t.string "years_active"
   end
 
   create_table "physical_components", force: :cascade do |t|


### PR DESCRIPTION
- Add `artist_death_date`, `artist_birth_date`, and `years_active` columns to `people` table
- Add `Artist_Born` and `Artist_Death_Date` Airtable columns into Airtable importer for `Person` model
- Update `PersonForm` to include 'Year of birth', 'Year of death', and 'Years of activity' fields 