### PR TITLE
BASIRA #123 - Add record ID link to sidebars

### DIFF
--- a/client/src/components/RecordHeader.js
+++ b/client/src/components/RecordHeader.js
@@ -6,6 +6,7 @@ import { withTranslation } from 'react-i18next';
 import {
   Button,
   Card,
+  Label,
   Popup
 } from 'semantic-ui-react';
 import _ from 'underscore';
@@ -19,6 +20,7 @@ type Props = Translateable & {
   ...EditContainerProps,
   description?: string,
   header?: string,
+  id?: string,
   image?: string,
   imageUpload?: boolean,
   includeInfoButton?: boolean,
@@ -34,7 +36,8 @@ type Props = Translateable & {
   onNotesChange: (notes: string) => void,
   onPublish: () => void,
   renderContent?: () => Element<any>,
-  renderImage?: () => Element<any>
+  renderImage?: () => Element<any>,
+  url?: string,
 };
 
 const POPUP_DELAY = 1000;
@@ -91,7 +94,18 @@ const RecordHeader = (props: Props) => {
       )}
       { props.description && (
         <Card.Description
-          content={props.description}
+          content={(
+            <>
+              {props.description}
+              {props.id && (
+                <Label
+                  as='a'
+                  content={props.id}
+                  href={props.url}
+                />
+              )}
+            </>
+          )}
         />
       )}
       { props.renderContent && props.renderContent() }

--- a/client/src/pages/admin/Artwork.js
+++ b/client/src/pages/admin/Artwork.js
@@ -70,12 +70,14 @@ const Artwork = (props: Props) => {
             />
           )}
           header={getTitle()}
+          id={props.item.id}
           image={getImage()}
           meta={props.item.date_descriptor}
           notes={props.item.notes_internal}
           published={props.item.published}
           onNotesChange={props.onTextInputChange.bind(this, 'notes_internal')}
           onPublish={props.onCheckboxInputChange.bind(this, 'published')}
+          url={`/admin/artworks/${props.item.id}`}
         />
       </SimpleEditPage.Header>
       <SimpleEditPage.Tab

--- a/client/src/pages/admin/Document.js
+++ b/client/src/pages/admin/Document.js
@@ -77,6 +77,7 @@ const Document = (props: Props) => {
             />
           )}
           header={props.item.name}
+          id={props.item.id}
           image={props.image && props.image.file_url}
           includeNotesButton={false}
           includePublishButton={false}
@@ -84,6 +85,7 @@ const Document = (props: Props) => {
           onFileEdit={props.onEditImage}
           onFileUpload={props.onSaveImage}
           preview={props.image && props.image.thumbnail_url}
+          url={`/admin/documents/${props.item.id}`}
         />
       </SimpleEditPage.Header>
       <SimpleEditPage.Tab

--- a/client/src/pages/admin/PhysicalComponent.js
+++ b/client/src/pages/admin/PhysicalComponent.js
@@ -55,12 +55,14 @@ const PhysicalComponent = (props: Props) => {
             />
           )}
           header={props.item.name}
+          id={props.item.id}
           image={props.image && props.image.file_url}
           includeNotesButton={false}
           includePublishButton={false}
           onFileDelete={props.onDeleteImage}
           onFileEdit={props.onEditImage}
           onFileUpload={props.onSaveImage}
+          url={`/admin/physical_components/${props.item.id}`}
         />
       </SimpleEditPage.Header>
       <SimpleEditPage.Tab

--- a/client/src/pages/admin/VisualContext.js
+++ b/client/src/pages/admin/VisualContext.js
@@ -61,12 +61,14 @@ const VisualContext = (props: Props) => {
             />
           )}
           header={props.item.name}
+          id={props.item.id}
           image={props.image && props.image.file_url}
           includeNotesButton={false}
           includePublishButton={false}
           onFileDelete={props.onDeleteImage}
           onFileEdit={props.onEditImage}
           onFileUpload={props.onSaveImage}
+          url={`/admin/visual_contexts/${props.item.id}`}
         />
       </SimpleEditPage.Header>
       <SimpleEditPage.Tab


### PR DESCRIPTION
### What this PR does

- Per #123:
  - Adds a link in the sidebar for Artworks, Documents, Visual Contexts, and Physical Components displaying the ID and linking to the record

### Status

- [x] Reviewed
- [x] Deployed

### Steps to test (when deployed)

1. Visit https://basiraproject-staging.herokuapp.com/
2. Log in
3. Click the "Edit" icon for an artwork
4. Verify that there is a label that says Artwork, and next to it an ID number, in the right sidebar
5. Right click the ID number, copy the link, and paste it into the browser bar
6. Verify that it takes you to the same page you were just on
7. Click the hamburger menu in the top left
8. Do steps 3-6 but for Documents, Physical Components, and Visual Contexts
