### PR TITLE
BASIRA #126 - Fix label and form for Place Modal

### DIFF
--- a/client/src/components/PlaceModal.js
+++ b/client/src/components/PlaceModal.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { withTranslation } from 'react-i18next';
 import { Form, Modal } from 'semantic-ui-react';
-import PlaceForm from './PersonForm';
+import PlaceForm from './PlaceForm';
 
 import type { EditContainerProps } from 'react-components/types';
 import type { Place } from '../types/Place';

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -336,6 +336,12 @@
       "people": "People"
     }
   },
+  "PlaceModal": {
+    "title": {
+      "add": "Add Place",
+      "edit": "Edit Place"
+    }
+  },
   "Places": {
     "columns": {
       "city": "City",


### PR DESCRIPTION
### What this PR does

- Per #126
  - Opens "Place Form" instead of "Person Form" when adding a Place during a location join
  - Creates i18n "Add Place" and "Edit Place" labels

### Status

- [x] Reviewed
- [x] Deployed

### Steps to test (when deployed)

1. Visit https://basiraproject-staging.herokuapp.com/
2. Log in
3. Navigate to People
4. Click Add
5. Go to the Locations tab for this new Person
6. Click Add
7. Next to the Place* dropdown, click Add
8. Verify that the correct fields for a Place show up (city, state, country, etc) and that the title of the modal is "Add Place"
	