### PR TITLE
BASIRA #124 - Redirect to parent of deleted record

### DIFF
--- a/client/src/components/AccordionMenu.js
+++ b/client/src/components/AccordionMenu.js
@@ -24,6 +24,7 @@ import type { Routeable } from '../types/Routeable';
 import type { Translateable } from '../types/Translateable';
 
 type Item = {
+  children?: [],
   level: number,
   name: string,
   parent?: Item,
@@ -80,16 +81,6 @@ const AccordionMenu = (props: Props) => {
   };
 
   /**
-   * Returns true if the passed item or any of its ancestors are the deleted item.
-   *
-   * @type {function(Item)}
-   */
-  const isDeleted = useCallback(
-    (item: Item) => (item === selectedItem && isItemActive(item)) || (item.parent && isDeleted(item.parent)),
-    [selectedItem]
-  );
-
-  /**
    * Returns true if the passed item is the active item.
    *
    * @param item
@@ -99,7 +90,24 @@ const AccordionMenu = (props: Props) => {
   const isItemActive = (item: Item) => props.location.pathname.match(item.path);
 
   /**
-   * Deletes the selected item and refreshes the data, or navigates to the artworks list.
+   * Returns true if the passed item, or its child at any level, is the active item.
+   *
+   * @param item
+   *
+   * @returns {boolean}
+   */
+  const isItemOrChildActive = (item: Item) => {
+    if (props.location.pathname.match(item.path)) {
+      return true;
+    }
+    if (item.children) {
+      return _.some(item.children, (child) => isItemOrChildActive(child));
+    }
+    return false;
+  };
+
+  /**
+   * Deletes the selected item and refreshes the data, or navigates to the nearest parent.
    *
    * @type {function(): void}
    */
@@ -108,9 +116,13 @@ const AccordionMenu = (props: Props) => {
       selectedItem
         .onDelete()
         .then(() => {
-          // If we're deleting the active record, or a parent of the active record, navigate to the artworks list
-          if (isDeleted(selectedItem)) {
-            props.history.push('/admin/artworks');
+          // If we're deleting the active record, or a parent of the active record, navigate to the
+          // nearest remaining parent. If there's no remaining parent, navigate to artworks list.
+          if (isItemOrChildActive(selectedItem)) {
+            const redirectPath = (selectedItem.parent && selectedItem.parent.path)
+              ? selectedItem.parent.path
+              : '/admin/artworks';
+            props.history.push(redirectPath);
           } else {
             setSelectedItem(null);
             fetchData();
@@ -229,7 +241,7 @@ const AccordionMenu = (props: Props) => {
     type: 'Document',
     level: 3,
     path: `/admin/documents/${doc.id}`,
-    parent,
+    parent: { ...parent, path: `/admin/visual_contexts/${parent.id}` },
     onDelete: () => DocumentsService.delete(doc)
   });
 
@@ -249,7 +261,7 @@ const AccordionMenu = (props: Props) => {
     type: 'Physical Component',
     level: 1,
     path: `/admin/physical_components/${pc.id}`,
-    parent,
+    parent: { ...parent, path: `/admin/artworks/${parent.id}` },
     onAdd: () => props.history.push('/admin/visual_contexts/new', {
       artwork_id: props.id,
       physical_component_id: pc.id
@@ -274,7 +286,7 @@ const AccordionMenu = (props: Props) => {
     type: 'Visual Context',
     level: 2,
     path: `/admin/visual_contexts/${vc.id}`,
-    parent,
+    parent: { ...parent, path: `/admin/physical_components/${parent.id}` },
     onAdd: () => props.history.push('/admin/documents/new', { artwork_id: props.id, visual_context_id: vc.id }),
     onDelete: () => VisualContextsService.delete(vc),
     children: _.map(vc.documents, transformDocument.bind(this, vc))


### PR DESCRIPTION
### What this PR does

- Per #124:
  - Redirects user to parent record on deletion
  - If a parent record of the active record is deleted, redirects to the nearest remaining parent, or the artworks list

### Status

- [x] Reviewed
- [x] Deployed

### Steps to test

1. Visit https://basiraproject-staging.herokuapp.com/
2. Log in to the admin interface
3. Open or create an artwork with nested children (physical components, visual contexts, documents)
4. Using the hamburger menu in the top left, click the Edit button for a child at any level below the top level (artwork)
5. Delete the child you are editing and verify that you are redirected to its parent
6. Do the same, but delete the parent of the child you are editing instead of the child itself, and verify that you are redirected to the parent of the item you deleted
7. Do the same, but delete the artwork at the root of the child you are editing, and verify that you are redirected to the artworks list