### PR TITLE
BASIRA #113  - Only generate thumbnail if variable

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -20,7 +20,7 @@ class Attachment < ApplicationRecord
   end
 
   def thumbnail_url
-    return nil unless self.file&.attached?
+    return nil unless self.file&.attached? and self.file.variable?
 
     url_for(self.file.variant(resize_to_fit: [250, nil]))
   end
@@ -28,7 +28,7 @@ class Attachment < ApplicationRecord
   private
 
   def generate_thumbnail
-    return unless self.file&.attached?
+    return unless self.file&.attached? and self.file.variable?
 
     CreateImageThumbnailJob.perform_later(self.id)
   end


### PR DESCRIPTION
On pages with invalid file attachments, `.variant` functions for generating thumbnails caused pages to fail loading.

Though our new validation of image MIME type should prevent such situations in the future, this is still a useful safeguard—in the case of corrupted or malformed image files, for example.

No real way to acceptance test this since we're removing the invalid attachments from production, and AFAIK there aren't any in staging.