### PR TITLE
BASIRA #152 - Bookmarks count

### DIFF
--- a/client/src/pages/admin/Document.js
+++ b/client/src/pages/admin/Document.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { EmbeddedList, LazyImage } from 'react-components';
 import { withRouter } from 'react-router-dom';
 import { Dropdown, Form, Grid } from 'semantic-ui-react';
@@ -49,13 +49,14 @@ const Document = (props: Props) => {
     }
   }, []);
 
-  const zeroToTenRangeOptionsList = [...(_.range(0, 10)), '10+'].map((el) => (
+  const zeroToTenRangeOptionsList = useMemo(() => [
+    ..._.range(0, 10).map((el) => ({ key: el, value: el, text: el })),
     {
-      key: el,
-      value: el,
-      text: el
+      key: 10,
+      value: 10,
+      text: '10+'
     }
-  ));
+  ], []);
 
   return (
     <SimpleEditPage


### PR DESCRIPTION
This pull request fixes a bug on the Documents page where saving a value of "10+" in the "Bookmarks/registers" field would not persist. This was happening because the underlying database column was expecting an integer value. The solution was to update the "10+" value to save as "10". It will still be displayed to the end-user as "10+".

![Screen Shot 2021-12-07 at 11 54 43 AM](https://user-images.githubusercontent.com/20641961/145072349-42cccba1-4166-4686-9d85-c69b762dc38e.png)
