### PR TITLE
BASIRA #163 - Document transcription field changes

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -18,8 +18,9 @@ class Document < ApplicationRecord
   # Resourceable parameters
   allow_params :visual_context_id, :name, :notes, :sewing_supports_visible, :number_sewing_supports, :number_fastenings,
                :inscriptions_on_binding, :inscription_text, :endband_present, :uncut_fore_edges, :fore_edge_text,
-               :bookmarks_registers, :text_columns, :ruling, :rubrication, :identity, :transcription, :artwork_id,
-               actions_attributes: [:id, :notes, :_destroy, qualifications_attributes: [:id, :value_list_id, :notes, :persistent, :_destroy]]
+               :bookmarks_registers, :text_columns, :ruling, :rubrication, :identity, :transcription, :transcription_expanded,
+               :transcription_translation, :artwork_id, actions_attributes: [:id, :notes, :_destroy,
+               qualifications_attributes: [:id, :value_list_id, :notes, :persistent, :_destroy]]
 
   private
 

--- a/app/serializers/documents_serializer.rb
+++ b/app/serializers/documents_serializer.rb
@@ -8,8 +8,9 @@ class DocumentsSerializer < BaseSerializer
   show_attributes :id, :name, :visual_context_id, :notes, :sewing_supports_visible, :number_sewing_supports,
                   :number_fastenings, :inscriptions_on_binding, :inscription_text, :endband_present,
                   :uncut_fore_edges, :fore_edge_text, :bookmarks_registers, :text_columns, :ruling, :rubrication,
-                  :identity, :transcription, qualifications: QualificationsSerializer,
-                  actions: [:id, :document_id, :notes, qualifications: QualificationsSerializer]
+                  :transcription, :transcription_expanded, :transcription_translation, :identity,
+                  qualifications: QualificationsSerializer, actions: [:id, :document_id, :notes,
+                  qualifications: QualificationsSerializer]
 
   show_attributes(:artwork_id) { |document| document.visual_context&.physical_component&.artwork_id }
 

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -217,7 +217,9 @@
       "spineFeatures": "Spine Features",
       "textColumns": "Text Columns",
       "textTechnology": "Text Technology",
-      "transcription": "Transcription",
+      "transcriptionDiplomatic": "Transcription: Diplomatic",
+      "transcriptionExpanded": "Transcription: Expanded",
+      "transcriptionTranslation": "Transcription: Translation",
       "typeOfIllumination": "Type of Illumination",
       "uncutForeEdges": "Uncut Fore-Edges"
     },

--- a/client/src/pages/admin/Document.js
+++ b/client/src/pages/admin/Document.js
@@ -485,11 +485,27 @@ const Document = (props: Props) => {
               />
               <Form.TextArea
                 error={props.isError('transcription')}
-                label={props.t('Document.labels.transcription')}
+                label={props.t('Document.labels.transcriptionDiplomatic')}
                 onChange={props.onTextInputChange.bind(this, 'transcription')}
                 required={props.isRequired('transcription')}
                 rows={5}
                 value={props.item.transcription || ''}
+              />
+              <Form.TextArea
+                error={props.isError('transcription_expanded')}
+                label={props.t('Document.labels.transcriptionExpanded')}
+                onChange={props.onTextInputChange.bind(this, 'transcription_expanded')}
+                required={props.isRequired('transcription_expanded')}
+                rows={5}
+                value={props.item.transcription_expanded || ''}
+              />
+              <Form.TextArea
+                error={props.isError('transcription_translation')}
+                label={props.t('Document.labels.transcriptionTranslation')}
+                onChange={props.onTextInputChange.bind(this, 'transcription_translation')}
+                required={props.isRequired('transcription_translation')}
+                rows={5}
+                value={props.item.transcription_translation || ''}
               />
               <ValueListDropdown
                 {...props}

--- a/client/src/transforms/Document.js
+++ b/client/src/transforms/Document.js
@@ -44,7 +44,9 @@ class Document extends FormDataTransform {
       'ruling',
       'rubrication',
       'identity',
-      'transcription'
+      'transcription',
+      'transcription_expanded',
+      'transcription_translation'
     ];
   }
 

--- a/client/src/types/Document.js
+++ b/client/src/types/Document.js
@@ -20,5 +20,7 @@ export type Document = {
   ruling: boolean,
   rubrication: boolean,
   identity: string,
-  transcription: string
+  transcription: string,
+  transcription_expanded: string,
+  transcription_translation: string
 };

--- a/db/migrate/20230403142734_add_expanded_and_translation_to_documents.rb
+++ b/db/migrate/20230403142734_add_expanded_and_translation_to_documents.rb
@@ -1,0 +1,6 @@
+class AddExpandedAndTranslationToDocuments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :documents, :transcription_expanded, :text
+    add_column :documents, :transcription_translation, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_07_171525) do
+ActiveRecord::Schema.define(version: 2023_04_03_142734) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "actions", force: :cascade do |t|
@@ -75,10 +76,10 @@ ActiveRecord::Schema.define(version: 2021_12_07_171525) do
     t.datetime "airtable_timestamp"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "created_by_id"
-    t.bigint "updated_by_id"
     t.integer "number_documents_visible"
     t.integer "documents_count", default: 0, null: false
+    t.bigint "created_by_id"
+    t.bigint "updated_by_id"
     t.index ["created_by_id"], name: "index_artworks_on_created_by_id"
     t.index ["updated_by_id"], name: "index_artworks_on_updated_by_id"
   end
@@ -123,9 +124,11 @@ ActiveRecord::Schema.define(version: 2021_12_07_171525) do
     t.datetime "airtable_timestamp"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "artwork_id"
     t.bigint "created_by_id"
     t.bigint "updated_by_id"
-    t.bigint "artwork_id"
+    t.text "transcription_expanded"
+    t.text "transcription_translation"
     t.index ["artwork_id"], name: "index_documents_on_artwork_id"
     t.index ["created_by_id"], name: "index_documents_on_created_by_id"
     t.index ["updated_by_id"], name: "index_documents_on_updated_by_id"


### PR DESCRIPTION
# Summary

- renames the "Transcription" field to "Transcription: Diplomatic", closing #162
  - as suggested in the issue, this is just a label rename that doesn't modify the database column
- adds "Transcription: Expanded" and "Transcription: Translation", closing #163 

# Notes

This branch is based off #167, so ideally that one should be merged first.

# Screenshot

![Screenshot 2023-04-03 at 10 46 41 AM](https://user-images.githubusercontent.com/64725469/229545247-1bead6c4-a28b-436b-b78f-8c35b22422c0.png)
