### PR TITLE
BASIRA #165 - Location and Participation role value lists

### DIFF
--- a/app/models/concerns/participateable.rb
+++ b/app/models/concerns/participateable.rb
@@ -9,7 +9,7 @@ module Participateable
     accepts_nested_attributes_for :participations, allow_destroy: true
 
     # Resourceable params
-    allow_params participations_attributes: [:id, :person_id, :role, :subrole, :description, :certainty, :notes, :_destroy]
+    allow_params participations_attributes: [:id, :person_id, :description, :certainty, :notes,
+    :_destroy, qualifications_attributes: [:id, :value_list_id, :notes, :persistent, :_destroy]]
   end
-
 end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -1,6 +1,7 @@
 class Participation < ApplicationRecord
   # Includes
   include Recordable
+  include Qualifiable
 
   # Relationships
   belongs_to :person

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -14,5 +14,6 @@ class Person < ApplicationRecord
   allow_params :name, :display_name, :person_type, :authorized_vocabulary, :url, :database_value, :comment, :part_of,
                :same_as, :artist_birth_date, :artist_death_date, :years_active,
                participations_attributes: [:id, :participateable_id, :participateable_type,
-                                           :role, :subrole, :description, :certainty, :notes, :_destroy]
+                                           :description, :certainty, :notes,
+                                           :_destroy, qualifications_attributes: [:id, :value_list_id, :notes, :persistent, :_destroy]]
 end

--- a/app/serializers/participations_serializer.rb
+++ b/app/serializers/participations_serializer.rb
@@ -1,4 +1,5 @@
 class ParticipationsSerializer < BaseSerializer
-  index_attributes :id, :person_id, :participateable_id, :participateable_type, :role, :subrole,
-                   person: PeopleSerializer, participateable: FactorySerializer
+  index_attributes :id, :person_id, :participateable_id, :participateable_type,
+                   person: PeopleSerializer, participateable: FactorySerializer,
+                   qualifications: QualificationsSerializer
 end

--- a/app/serializers/places_serializer.rb
+++ b/app/serializers/places_serializer.rb
@@ -2,6 +2,6 @@ class PlacesSerializer < BaseSerializer
   index_attributes :id, :name, :place_type, :lat, :long, :city, :state, :country
 
   show_attributes :id, :name, :place_type, :lat, :long, :city, :state, :country, :url, :database_value, :notes,
-                   :same_as, :part_of, locations: [:id, :locateable_id, :locateable_type, :subrole, :description,
+                   :same_as, :part_of, locations: [:id, :locateable_id, :locateable_type, :description,
                                                    :certainty, :notes, locateable: FactorySerializer, qualifications: QualificationsSerializer]
 end

--- a/client/src/components/LocationModal.js
+++ b/client/src/components/LocationModal.js
@@ -109,12 +109,11 @@ const LocationModal = (props: Props) => (
         label={props.t('LocationModal.labels.role')}
         object='Location'
       />
-      <Form.Input
-        error={props.isError('subrole')}
+      <ValueListDropdown
+        {...props}
+        group='Subrole'
         label={props.t('LocationModal.labels.subrole')}
-        onChange={props.onTextInputChange.bind(this, 'subrole')}
-        required={props.isRequired('subrole')}
-        value={props.item.subrole || ''}
+        object='Location'
       />
       <Form.Input
         error={props.isError('repository_work_url')}

--- a/client/src/components/ParticipationModal.js
+++ b/client/src/components/ParticipationModal.js
@@ -10,6 +10,7 @@ import Certainty from '../resources/Certainty.json';
 import People from '../services/People';
 import Person from '../transforms/Person';
 import PersonModal from './PersonModal';
+import ValueListDropdown from './ValueListDropdown';
 
 import type { EditContainerProps } from 'react-components/types';
 import type { Participation } from '../types/Participation';
@@ -82,19 +83,17 @@ const ParticipationModal = (props: Props) => (
           />
         </Form.Input>
       )}
-      <Form.Input
-        error={props.isError('role')}
+      <ValueListDropdown
+        {...props}
+        group='Participation Role'
         label={props.t('ParticipationModal.labels.role')}
-        onChange={props.onTextInputChange.bind(this, 'role')}
-        required={props.isRequired('role')}
-        value={props.item.role || ''}
+        object='Person'
       />
-      <Form.Input
-        error={props.isError('subrole')}
+      <ValueListDropdown
+        {...props}
+        group='Participation Subrole'
         label={props.t('ParticipationModal.labels.subrole')}
-        onChange={props.onTextInputChange.bind(this, 'subrole')}
-        required={props.isRequired('subrole')}
-        value={props.item.subrole || ''}
+        object='Person'
       />
       <Form.TextArea
         error={props.isError('description')}

--- a/client/src/pages/admin/Artwork.js
+++ b/client/src/pages/admin/Artwork.js
@@ -356,7 +356,8 @@ const Artwork = (props: Props) => {
             )
           }, {
             name: 'role',
-            label: props.t('Artwork.participations.columns.role')
+            label: props.t('Artwork.participations.columns.role'),
+            resolve: (pa) => Qualifiables.getValueListValue(pa, 'Person', 'Participation Role')
           }]}
           items={props.item.participations}
           key='participations'

--- a/client/src/transforms/Participations.js
+++ b/client/src/transforms/Participations.js
@@ -1,6 +1,9 @@
 // @flow
 
 import NestedAttributes from './NestedAttributes';
+import Qualifications from './Qualifications';
+import _ from 'underscore';
+import String from '../utils/String';
 
 import type { Participateable } from '../types/concerns/Participateable';
 
@@ -18,8 +21,6 @@ class Participations extends NestedAttributes {
       'person_id',
       'participateable_id',
       'participateable_type',
-      'role',
-      'subrole',
       'description',
       'certainty',
       'notes',
@@ -36,7 +37,13 @@ class Participations extends NestedAttributes {
    * @param collection
    */
   appendFormData(formData: FormData, prefix: string, record: any, collection: string = this.PARAM_NAME) {
-    super.appendFormData(formData, prefix, record, collection);
+    _.each(record[collection], (item, index) => {
+      _.each(this.getPayloadKeys(), (key) => {
+        formData.append(`${prefix}[${collection}][${index}][${key}]`, String.toString(item[key]));
+      });
+
+      Qualifications.appendFormData(formData, `${prefix}[${this.PARAM_NAME}][${index}]`, item);
+    });
   }
 
   /**

--- a/client/src/types/Location.js
+++ b/client/src/types/Location.js
@@ -10,8 +10,6 @@ export type Location = Qualifiable & {
   locateable_id: number,
   locateable_type: string,
   locateable: Artwork | Person,
-  role: string,
-  subrole: string,
   description: string,
   certainty: number,
   notes: string,

--- a/client/src/types/Participation.js
+++ b/client/src/types/Participation.js
@@ -5,8 +5,6 @@ export type Participation = {
   person_id: number,
   participateable_id: number,
   participateable_type: string,
-  role: string,
-  subrole: string,
   description: string,
   certainty: string,
   notes: string

--- a/db/data/20230404202105_convert_participations_roles_to_qualifications.rb
+++ b/db/data/20230404202105_convert_participations_roles_to_qualifications.rb
@@ -1,0 +1,39 @@
+class ConvertParticipationsRolesToQualifications < ActiveRecord::Migration[6.0]
+  def up
+    # Roles
+    execute <<-SQL.squish
+      INSERT INTO value_lists (human_name, object, "group", created_at, updated_at)
+      SELECT DISTINCT participations.role, 'Person', 'Participation Role', current_timestamp, current_timestamp
+        FROM participations
+    SQL
+
+    execute <<-SQL.squish
+      INSERT INTO qualifications (qualifiable_id, qualifiable_type, value_list_id)
+      SELECT participations.id, 'ParticipationRole', value_lists.id
+        FROM participations
+        JOIN value_lists ON value_lists.object = 'Person'
+                        AND value_lists.group = 'Participation Role'
+                        AND value_lists.human_name = participations.role
+    SQL
+
+    # Subroles
+    execute <<-SQL.squish
+      INSERT INTO value_lists (human_name, object, "group", created_at, updated_at)
+      SELECT DISTINCT participations.subrole, 'Person', 'Participation Subrole', current_timestamp, current_timestamp
+        FROM participations
+    SQL
+
+    execute <<-SQL.squish
+      INSERT INTO qualifications (qualifiable_id, qualifiable_type, value_list_id)
+      SELECT participations.id, 'ParticipationSubrole', value_lists.id
+        FROM participations
+        JOIN value_lists ON value_lists.object = 'Person'
+                        AND value_lists.group = 'Participation Subrole'
+                        AND value_lists.human_name = participations.subrole
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20230404203137_convert_location_roles_to_qualifications.rb
+++ b/db/data/20230404203137_convert_location_roles_to_qualifications.rb
@@ -1,0 +1,22 @@
+class ConvertLocationRolesToQualifications < ActiveRecord::Migration[6.0]
+  def up
+    execute <<-SQL.squish
+      INSERT INTO value_lists (human_name, object, "group", created_at, updated_at)
+      SELECT DISTINCT locations.subrole, 'Location', 'Subrole', current_timestamp, current_timestamp
+        FROM locations
+    SQL
+
+    execute <<-SQL.squish
+      INSERT INTO qualifications (qualifiable_id, qualifiable_type, value_list_id)
+      SELECT locations.id, 'Location', value_lists.id
+        FROM locations
+        JOIN value_lists ON value_lists.object = 'Location'
+                        AND value_lists.group = 'Subrole'
+                        AND value_lists.human_name = locations.subrole
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20230403160537)
+DataMigrate::Data.define(version: 20230404203137)

--- a/db/migrate/20230406192435_remove_participation_and_location_roles.rb
+++ b/db/migrate/20230406192435_remove_participation_and_location_roles.rb
@@ -1,0 +1,7 @@
+class RemoveParticipationAndLocationRoles < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :participations, :role, :string
+    remove_column :participations, :subrole, :string
+    remove_column :locations, :subrole, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_04_190450) do
+ActiveRecord::Schema.define(version: 2023_04_06_192435) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -40,7 +41,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_04_190450) do
     t.text "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum"
-    t.datetime "created_at", precision: nil, null: false
+    t.datetime "created_at", null: false
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -146,7 +147,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_04_190450) do
     t.string "locateable_type", null: false
     t.bigint "locateable_id", null: false
     t.string "role"
-    t.string "subrole"
     t.text "description"
     t.integer "certainty"
     t.text "notes"
@@ -165,8 +165,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_04_190450) do
     t.bigint "person_id", null: false
     t.string "participateable_type", null: false
     t.bigint "participateable_id", null: false
-    t.string "role"
-    t.string "subrole"
     t.text "description"
     t.integer "certainty"
     t.text "notes"


### PR DESCRIPTION
# Summary

- converts the following three fields from `string`s to value lists
  - `participations.role`
  - `participations.subrole`
  - `locations.subrole`
- makes the necessary adjustments in the models, serializers, etc.
- updates the frontend components to send, receive, and display the new `qualifications`

I used #169 as a template, although this PR was a lot simpler on the frontend because the transforms were already set up.

# Screenshots

## Participations

![Screenshot 2023-04-05 at 10 55 48 AM](https://user-images.githubusercontent.com/64725469/230120319-19630e17-1dfc-4e1a-be84-50b4400787ac.png)

## Locations

![Screenshot 2023-04-05 at 10 57 40 AM](https://user-images.githubusercontent.com/64725469/230120831-4a71cf94-1592-4d98-8a6a-a98dcab90238.png)
