### PR TITLE
BASIRA #165 - Remove old role fields from models and serializers

### DIFF
--- a/app/models/concerns/locateable.rb
+++ b/app/models/concerns/locateable.rb
@@ -9,7 +9,7 @@ module Locateable
     accepts_nested_attributes_for :locations, allow_destroy: true
 
     # Resourceable params
-    allow_params locations_attributes: [:id, :place_id, :subrole, :description, :certainty, 
+    allow_params locations_attributes: [:id, :place_id, :description, :certainty,
                                         :notes, :repository_work_url, :_destroy,
                                         qualifications_attributes: [:id, :value_list_id, :notes, :persistent, :_destroy]]
   end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -10,6 +10,6 @@ class Place < ApplicationRecord
 
   # Resourceable parameters
   allow_params :name, :place_type, :lat, :long, :city, :state, :country, :url, :database_value, :notes, :same_as,
-               :part_of, locations_attributes: [:id, :locateable_id, :locateable_type, :subrole, :description, :certainty,
+               :part_of, locations_attributes: [:id, :locateable_id, :locateable_type, :description, :certainty,
                                                 :notes, :_destroy, qualifications_attributes: [:id, :value_list_id, :notes, :persistent, :_destroy]]
 end

--- a/app/serializers/concerns/locateable_serializer.rb
+++ b/app/serializers/concerns/locateable_serializer.rb
@@ -2,7 +2,7 @@ module LocateableSerializer
   extend ActiveSupport::Concern
 
   included do
-    show_attributes locations: [:id, :place_id, :role, :subrole, :description, :certainty, 
+    show_attributes locations: [:id, :place_id, :description, :certainty,
                                 :notes, :repository_work_url, place: PlacesSerializer,
                                 qualifications: QualificationsSerializer]
   end


### PR DESCRIPTION
# Summary

When I created #171, I seem to have missed removing a few `role` and `subrole` fields from models and serializers, or maybe they got added back in through a rebase at some point. Either way, they were causing a crash when trying to bring up the Artwork edit page.

# Testing

As this fixes a crash in some of the edit pages, testing should be a quick check that you can load the edit pages for Artworks, Documents, Visual Contexts, and Physical Components without a crash.