### PR TITLE
BASIRA #219 - Document actions error

### DIFF
--- a/client/src/components/DocumentActions.js
+++ b/client/src/components/DocumentActions.js
@@ -42,7 +42,7 @@ const DocumentActions = (props: Props) => {
     const verb = _.findWhere(action.qualifications, { value_list_object: 'Document', value_list_group: 'Action' });
     const entity = _.findWhere(action.qualifications, { value_list_object: 'Action', value_list_group: 'Entity' });
 
-    return t('Document.labels.action', { verb: verb.value_list.human_name, entity: entity.value_list.human_name });
+    return t('Document.labels.action', { verb: verb?.value_list?.human_name, entity: entity?.value_list?.human_name });
   }, []);
 
   if (!props.items) {


### PR DESCRIPTION
This pull request fixes a bug that occurred in the DocumentActions component when an action existed without a verb or entity. The solution was to use the `?` operator to check for presence in the object.