### PR TITLE
BASIRA #222 - Repository State facet sort

### DIFF
--- a/client/src/components/SearchFacets.js
+++ b/client/src/components/SearchFacets.js
@@ -109,6 +109,7 @@ const SearchFacets = (props: any) => {
         defaultActive={false}
         showMore
         showMoreLimit={MAX_SHOW_MORE_LIMIT}
+        sortBy={['name']}
         title={getLabel('artwork.locations.state_facet')}
         useRefinementList={useRefinementList}
       />


### PR DESCRIPTION
This pull request updates the Repository State facet to order the facets by name, instead of frequency.

![Screen Shot 2023-08-07 at 10 44 12 AM](https://github.com/performant-software/basira/assets/20641961/c85e7bad-295e-4388-93fc-a022e07d99a0)
