### PR TITLE
BASIRA #241 - Image rights icons

### DIFF
--- a/client/src/components/ImageInfo.js
+++ b/client/src/components/ImageInfo.js
@@ -29,6 +29,7 @@ const Item = (props: ItemProps) => {
         { props.icon && (
           <Icon
             circular
+            color='grey'
             inverted
             name={props.icon}
             size='large'


### PR DESCRIPTION
This pull request adjusts the colors of the image rights icons from black to grey.

![Screen Shot 2023-08-18 at 12 08 38 PM](https://github.com/performant-software/basira/assets/20641961/635c541a-4952-43ed-b2b5-081a5ad5f88d)
