### PR TITLE
BASIRA #247 - Iconography

### DIFF
--- a/client/src/pages/Document.js
+++ b/client/src/pages/Document.js
@@ -179,7 +179,8 @@ const Document = () => {
             label: t('Document.labels.bindingIconography'),
             qualification: {
               object: 'Document',
-              group: 'Iconography'
+              group: 'Iconography',
+              formField: 'binding_iconography'
             }
           }]}
           item={item}
@@ -379,7 +380,7 @@ const Document = () => {
             label: t('Document.labels.illuminationIconography'),
             qualification: {
               object: 'Document',
-              group: 'Illumination Iconography',
+              group: 'Iconography',
               formField: 'illumination_iconography'
             }
           }]}


### PR DESCRIPTION
This pull request fixes a bug with the way the Binding Iconography and Illumination Iconography fields were being displayed on the document detail page. The issue was that values for both fields were being displayed in the Binding Iconography field because of a lack of a `formField` property on the Binding Iconography field and an incorrect `group` property on the Illumination Iconography field.

![Screenshot 2023-10-23 at 1 03 20 PM](https://github.com/performant-software/basira/assets/20641961/f8c96eee-e98c-46ed-a750-55c332200dce)
