### PR TITLE
BASIRA #255 - Aperture facet

### DIFF
--- a/app/models/search/document.rb
+++ b/app/models/search/document.rb
@@ -50,7 +50,7 @@ module Search
       search_attribute :document_type, object: 'Document', group: 'Document Type', multiple: true, facet: true
       search_attribute :orientation, object: 'Document', group: 'Orientation (spine)', multiple: true, facet: true
       search_attribute :size, object: 'Document', group: 'Size', facet: true
-      search_attribute :aperture, object: 'Document', group: 'Aperture', facet: true
+      search_attribute :aperture, object: 'Document', group: 'Aperture', multiple: true, facet: true
       search_attribute :binding_type, object: 'Document', group: 'Binding Type', multiple: true, facet: true
       search_attribute :binding_color, object: 'Document', group: 'Color', form_field: 'binding_color', multiple: true, facet: true
       search_attribute :number_sewing_supports, facet: true

--- a/typesense/schema.json
+++ b/typesense/schema.json
@@ -119,7 +119,7 @@
     },
     {
       "name": "aperture_facet",
-      "type": "string",
+      "type": "string[]",
       "facet": true,
       "optional": true
     },


### PR DESCRIPTION
This pull request fixes an issue in the Document Details > Aperture facet where the search UI was not allowing selecting multiple values when the "Match all values" toggle was selected. The issue was that we did not have the field configured for multiple values in Typesense.