### PR TITLE
BASIRA #258 - ID fields

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -62,6 +62,7 @@
       "documentsVisible": "Documents Visible",
       "endDate": "End date",
       "height": "Height",
+      "id": "Artworks/{{id}}",
       "objectWorkTypes": "Object/Work Type(s)",
       "materials": "Material(s)",
       "notes": "Notes",
@@ -376,6 +377,7 @@
     "labels": {
       "depth": "Depth",
       "height": "Height",
+      "id": "Physical_Components/{{id}}",
       "name": "Name",
       "notes": "Notes",
       "width": "Width"
@@ -626,6 +628,7 @@
       "depth": "Depth",
       "generalSubjectGenre": "General Subject/Genre",
       "height": "Height",
+      "id": "Visual_Contexts/{{id}}",
       "name": "Name",
       "notes": "Notes",
       "specificSubjectIconography": "Specific Subject/Iconography",

--- a/client/src/pages/Artwork.js
+++ b/client/src/pages/Artwork.js
@@ -55,6 +55,10 @@ const Artwork = () => {
       <RecordPage.Section>
         <AttributesGrid
           attributes={[{
+            name: 'id',
+            label: t('Common.labels.id'),
+            renderValue: () => t('Artwork.labels.id', { id: item.id })
+          }, {
             name: 'date_start',
             label: t('Artwork.labels.startDate')
           }, {

--- a/client/src/pages/PhysicalComponent.js
+++ b/client/src/pages/PhysicalComponent.js
@@ -40,6 +40,10 @@ const PhysicalComponent = () => {
       <RecordPage.Section>
         <AttributesGrid
           attributes={[{
+            name: 'id',
+            label: t('Common.labels.id'),
+            renderValue: () => t('PhysicalComponent.labels.id', { id: item.id })
+          }, {
             name: 'height',
             label: t('PhysicalComponent.labels.height')
           }, {

--- a/client/src/pages/VisualContext.js
+++ b/client/src/pages/VisualContext.js
@@ -41,17 +41,21 @@ const VisualContext = () => {
       <RecordPage.Section>
         <AttributesGrid
           attributes={[{
+            name: 'id',
+            label: t('Common.labels.id'),
+            renderValue: () => t('VisualContext.labels.id', { id: item.id })
+          }, {
             name: 'height',
-            label: t('PhysicalComponent.labels.height')
+            label: t('VisualContext.labels.height')
           }, {
             name: 'width',
-            label: t('PhysicalComponent.labels.width')
+            label: t('VisualContext.labels.width')
           }, {
             name: 'depth',
-            label: t('PhysicalComponent.labels.depth')
+            label: t('VisualContext.labels.depth')
           }, {
             name: 'notes',
-            label: t('PhysicalComponent.labels.notes')
+            label: t('VisualContext.labels.notes')
           }, {
             name: 'general_subject_genre',
             label: t('VisualContext.labels.generalSubjectGenre'),


### PR DESCRIPTION
This pull request adds an "ID" field to the Artwork, Physical Component, and Visual Context pages. Each value will be prefixed with the name of the record type (e.g. "Artworks/123", "PhysicalComponents/456", etc).

## Artwork
![Screenshot 2024-11-29 at 12 42 10 PM](https://github.com/user-attachments/assets/5304fc13-3d4d-4088-af58-417a14165c2e)

## Physical Component
![Screenshot 2024-11-29 at 12 42 19 PM](https://github.com/user-attachments/assets/27fd5bd2-72a8-4f58-a597-bacf6a2e4e14)

## Visual Context
![Screenshot 2024-11-29 at 12 42 30 PM](https://github.com/user-attachments/assets/c1cf63fb-f41c-4fa2-b3cf-544b8df08536)
