### PR TITLE
BASIRA #261 - Authorized vocabulary

### DIFF
--- a/app/models/value_list.rb
+++ b/app/models/value_list.rb
@@ -6,7 +6,7 @@ class ValueList < ApplicationRecord
   has_many :qualifications
 
   # Resource params
-  allow_params :authorized_vocabulary, :comment, :object, :group, :human_name, :url_database_value
+  allow_params :authorized_vocabulary, :comment, :object, :group, :human_name, :authorized_vocabulary_url, :database_value
 
   # Scopes
   scope :entity_description, -> { where(object: 'Action', group: 'Characteristic') }

--- a/app/serializers/value_lists_serializer.rb
+++ b/app/serializers/value_lists_serializer.rb
@@ -1,7 +1,7 @@
 class ValueListsSerializer < BaseSerializer
-  index_attributes :id, :object, :group, :human_name, :url_database_value, :authorized_vocabulary,
-                   :comment, :qualifications_count
+  index_attributes :id, :object, :group, :human_name, :authorized_vocabulary, :authorized_vocabulary_url,
+                   :database_value, :comment, :qualifications_count
 
-  show_attributes :id, :object, :group, :human_name, :url_database_value, :authorized_vocabulary,
-                  :comment, :qualifications_count
+  show_attributes :id, :object, :group, :human_name, :authorized_vocabulary, :authorized_vocabulary_url,
+                  :database_value, :comment, :qualifications_count
 end

--- a/app/services/airtable_importer/models/value_list.rb
+++ b/app/services/airtable_importer/models/value_list.rb
@@ -22,7 +22,7 @@ module AirtableImporter
           attribute_name: :authorized_vocabulary,
           airtable_name: 'Authorized vocabulary'
         }, {
-          attribute_name: :url_database_value,
+          attribute_name: :authorized_vocabulary_url,
           airtable_name: 'URL/Database value (if applicable)'
         }, {
           attribute_name: :comment,

--- a/client/src/components/ValueListModal.js
+++ b/client/src/components/ValueListModal.js
@@ -78,11 +78,18 @@ const ValueListModal = (props: Props) => {
           />
         </Form.Input>
         <Form.Input
-          error={props.isError('url_database_value')}
-          label={props.t('ValueList.labels.urlDatabaseValue')}
-          onChange={props.onTextInputChange.bind(this, 'url_database_value')}
-          required={props.isRequired('url_database_value')}
-          value={props.item.url_database_value || ''}
+          error={props.isError('authorized_vocabulary_url')}
+          label={props.t('ValueList.labels.authorizedVocabularyUrl')}
+          onChange={props.onTextInputChange.bind(this, 'authorized_vocabulary_url')}
+          required={props.isRequired('authorized_vocabulary_url')}
+          value={props.item.authorized_vocabulary_url || ''}
+        />
+        <Form.Input
+          error={props.isError('database_value')}
+          label={props.t('ValueList.labels.databaseValue')}
+          onChange={props.onTextInputChange.bind(this, 'database_value')}
+          required={props.isRequired('database_value')}
+          value={props.item.database_value || ''}
         />
         <Form.TextArea
           error={props.isError('comment')}

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -589,12 +589,13 @@
   "ValueList": {
     "labels": {
       "authorizedVocabulary": "Authorized vocabulary",
+      "authorizedVocabularyUrl": "Authorized vocabulary URL",
       "comment": "Comment",
+      "databaseValue": "Database value",
       "groupName": "Group name",
       "humanName": "Human name",
       "linkedRecords": "Linked records",
-      "objectName": "Object name",
-      "urlDatabaseValue": "URL/Database value"
+      "objectName": "Object name"
     },
     "title": {
       "add": "Add value list item",

--- a/client/src/transforms/ValueList.js
+++ b/client/src/transforms/ValueList.js
@@ -17,7 +17,8 @@ class ValueList extends BaseTransform {
     'group',
     'human_name',
     'authorized_vocabulary',
-    'url_database_value',
+    'authorized_vocabulary_url',
+    'database_value',
     'comment',
     '_destroy'
   ];

--- a/db/migrate/20241203180855_rename_value_lists_url_database_value.rb
+++ b/db/migrate/20241203180855_rename_value_lists_url_database_value.rb
@@ -1,0 +1,5 @@
+class RenameValueListsUrlDatabaseValue < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :value_lists, :url_database_value, :authorized_vocabulary_url
+  end
+end

--- a/db/migrate/20241203181033_add_value_lists_database_value.rb
+++ b/db/migrate/20241203181033_add_value_lists_database_value.rb
@@ -1,0 +1,5 @@
+class AddValueListsDatabaseValue < ActiveRecord::Migration[7.0]
+  def change
+    add_column :value_lists, :database_value, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_27_155237) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_03_181033) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -286,7 +286,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_27_155237) do
     t.string "object"
     t.string "group"
     t.string "human_name"
-    t.string "url_database_value"
+    t.string "authorized_vocabulary_url"
     t.text "comment"
     t.string "authorized_vocabulary"
     t.string "airtable_id"
@@ -296,6 +296,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_27_155237) do
     t.integer "qualifications_count", default: 0, null: false
     t.bigint "created_by_id"
     t.bigint "updated_by_id"
+    t.string "database_value"
     t.index ["created_by_id"], name: "index_value_lists_on_created_by_id"
     t.index ["updated_by_id"], name: "index_value_lists_on_updated_by_id"
   end


### PR DESCRIPTION
This pull request splits the "URL/Database value" field on `value_lists` into "Authorized vocabulary URL" and "Database value". Existing values will remain in "Authorized vocabulary URL".

![Screenshot 2024-12-03 at 2 32 20 PM](https://github.com/user-attachments/assets/285a3900-80dd-4946-92cd-4e97efca3987)
