### PR TITLE
BASIRA #271 - Timestamps

### DIFF
--- a/app/serializers/documents_serializer.rb
+++ b/app/serializers/documents_serializer.rb
@@ -8,7 +8,7 @@ class DocumentsSerializer < BaseSerializer
   show_attributes :id, :name, :visual_context_id, :notes, :number_sewing_supports, :number_fastenings,
                   :inscriptions_on_binding, :inscription_text, :endband_present, :uncut_fore_edges, :fore_edge_text,
                   :bookmarks_registers, :text_columns, :ruling, :rubrication, :transcription, :transcription_expanded,
-                  :transcription_translation, :identity,
+                  :transcription_translation, :identity, :created_at, :updated_at,
                   qualifications: QualificationsSerializer, actions: [:id, :document_id, :notes,
                   qualifications: QualificationsSerializer]
 

--- a/app/serializers/physical_components_serializer.rb
+++ b/app/serializers/physical_components_serializer.rb
@@ -5,7 +5,7 @@ class PhysicalComponentsSerializer < BaseSerializer
 
   index_attributes :id, :name
 
-  show_attributes :id, :artwork_id, :name, :height, :width, :depth, :notes
+  show_attributes :id, :artwork_id, :name, :height, :width, :depth, :notes, :created_at, :updated_at
 
   nested_attributes :id, :artwork_id, :name,
                     primary_attachment: [:id, :file_url, :primary, :thumbnail_url],

--- a/app/serializers/visual_contexts_serializer.rb
+++ b/app/serializers/visual_contexts_serializer.rb
@@ -5,7 +5,9 @@ class VisualContextsSerializer < BaseSerializer
 
   index_attributes :id, :name
 
-  show_attributes :id, :physical_component_id, :name, :height, :width, :depth, :notes, :beta, qualifications: QualificationsSerializer
+  show_attributes :id, :physical_component_id, :name, :height, :width, :depth, :notes, :beta, :created_at, :updated_at,
+                  qualifications: QualificationsSerializer
+
   show_attributes(:artwork_id) { |visual_context| visual_context.physical_component&.artwork_id }
 
   nested_attributes :id, :physical_component_id, :name,

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -168,10 +168,12 @@
     },
     "labels": {
       "artwork": "Artwork",
+      "created": "Record created",
       "details": "Details",
       "document": "Document",
       "id": "ID",
       "physicalComponent": "Physical Component",
+      "updated": "Record updated",
       "visualContext": "Visual Context"
     },
     "messages": {

--- a/client/src/pages/Artwork.js
+++ b/client/src/pages/Artwork.js
@@ -7,6 +7,7 @@ import ArtworkCreators from '../components/ArtworkCreators';
 import ArtworkTitles from '../components/ArtworkTitles';
 import ArtworksService from '../services/Artworks';
 import AttributesGrid from '../components/AttributesGrid';
+import { getDateTimeView } from '../utils/Date';
 import { getPrimaryTitle } from '../utils/Artwork';
 import Locations from '../components/Locations';
 import RecordPage from '../components/RecordPage';
@@ -42,6 +43,14 @@ const Artwork = () => {
               name: 'id',
               label: t('Common.labels.id'),
               renderValue: () => t('Artwork.labels.id', { id: item.id })
+            }, {
+              name: 'created_at',
+              label: t('Common.labels.created'),
+              renderValue: () => getDateTimeView(item.created_at)
+            }, {
+              name: 'updated_at',
+              label: t('Common.labels.updated'),
+              renderValue: () => getDateTimeView(item.updated_at)
             }, {
               name: 'date_start',
               label: t('Artwork.labels.startDate')

--- a/client/src/pages/Document.js
+++ b/client/src/pages/Document.js
@@ -8,6 +8,7 @@ import _ from 'underscore';
 import AttributesGrid from '../components/AttributesGrid';
 import DocumentActions from '../components/DocumentActions';
 import DocumentsService from '../services/Documents';
+import { getDateTimeView } from '../utils/Date';
 import RecordPage from '../components/RecordPage';
 import useCurrentRecord from '../hooks/CurrentRecord';
 
@@ -44,6 +45,14 @@ const Document = () => {
             }, {
               name: 'name',
               label: t('Document.labels.name')
+            }, {
+              name: 'created_at',
+              label: t('Common.labels.created'),
+              renderValue: () => getDateTimeView(item.created_at)
+            }, {
+              name: 'updated_at',
+              label: t('Common.labels.updated'),
+              renderValue: () => getDateTimeView(item.updated_at)
             }, {
               name: 'document_type',
               label: t('Document.labels.documentType'),

--- a/client/src/pages/PhysicalComponent.js
+++ b/client/src/pages/PhysicalComponent.js
@@ -3,6 +3,7 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import AttributesGrid from '../components/AttributesGrid';
+import { getDateTimeView } from '../utils/Date';
 import PhysicalComponentsService from '../services/PhysicalComponents';
 import RecordPage from '../components/RecordPage';
 import useCurrentRecord from '../hooks/CurrentRecord';
@@ -37,6 +38,14 @@ const PhysicalComponent = () => {
               name: 'id',
               label: t('Common.labels.id'),
               renderValue: () => t('PhysicalComponent.labels.id', { id: item.id })
+            }, {
+              name: 'created_at',
+              label: t('Common.labels.created'),
+              renderValue: () => getDateTimeView(item.created_at)
+            }, {
+              name: 'updated_at',
+              label: t('Common.labels.updated'),
+              renderValue: () => getDateTimeView(item.updated_at)
             }, {
               name: 'height',
               label: t('PhysicalComponent.labels.height')

--- a/client/src/pages/VisualContext.js
+++ b/client/src/pages/VisualContext.js
@@ -4,9 +4,10 @@ import React, { useCallback } from 'react';
 import { BooleanIcon } from '@performant-software/semantic-components';
 import { useTranslation } from 'react-i18next';
 import AttributesGrid from '../components/AttributesGrid';
-import VisualContextsService from '../services/VisualContexts';
+import { getDateTimeView } from '../utils/Date';
 import RecordPage from '../components/RecordPage';
 import useCurrentRecord from '../hooks/CurrentRecord';
+import VisualContextsService from '../services/VisualContexts';
 
 const VisualContext = () => {
   /**
@@ -38,6 +39,14 @@ const VisualContext = () => {
               name: 'id',
               label: t('Common.labels.id'),
               renderValue: () => t('VisualContext.labels.id', { id: item.id })
+            }, {
+              name: 'created_at',
+              label: t('Common.labels.created'),
+              renderValue: () => getDateTimeView(item.created_at)
+            }, {
+              name: 'updated_at',
+              label: t('Common.labels.updated'),
+              renderValue: () => getDateTimeView(item.updated_at)
             }, {
               name: 'height',
               label: t('VisualContext.labels.height')

--- a/client/src/utils/Date.js
+++ b/client/src/utils/Date.js
@@ -1,0 +1,13 @@
+// @flow
+
+/**
+ * Returns the date/time view for the passed date string.
+ *
+ * @param timestamp
+ *
+ * @returns {`${string} ${string}`}
+ */
+export const getDateTimeView = (timestamp) => {
+  const date = new Date(timestamp);
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+};


### PR DESCRIPTION
This pull request adds the `created_at` and `updated_at` timestamps to the Artwork, Physical Component, Visual Context, and Document detail pages.

![Screenshot 2024-12-10 at 11 51 00 AM](https://github.com/user-attachments/assets/5479abd1-a33f-4424-90d9-615777bd073a)
