### PR TITLE
BASIRA #272 - Documents count

### DIFF
--- a/app/models/search/artwork.rb
+++ b/app/models/search/artwork.rb
@@ -10,6 +10,7 @@ module Search
       search_attribute :id
       search_attribute :date_descriptor
       search_attribute :date_start
+      search_attribute :documents_count, facet: true
       search_attribute :object_work_type, object: 'Artwork', group: 'Object/Work Type', multiple: true, facet: true
       search_attribute :materials, object: 'Artwork', group: 'Material', multiple: true, facet: true
       search_attribute :techniques, object: 'Artwork', group: 'Technique', multiple: true, facet: true

--- a/client/src/components/SearchFacets.js
+++ b/client/src/components/SearchFacets.js
@@ -189,6 +189,14 @@ const SearchFacets = (props: any) => {
         toggleable
         useRefinementList={useRefinementList}
       />
+      <FacetSlider
+        attribute='artwork.documents_count_facet'
+        defaultActive={false}
+        editable
+        ref={setRef}
+        title={getLabel('artwork.documents_count_facet')}
+        useRangeSlider={useRange}
+      />
       <Header
         as='h3'
         content={t('Search.facets.headers.visualContext')}

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -461,6 +461,7 @@
           "nationality": "Creator Origin"
         },
         "dateRange": "Date",
+        "documentsCount": "Number of Documents",
         "materials": "Materials",
         "locations": {
           "name": "Repository",

--- a/typesense/schema.json
+++ b/typesense/schema.json
@@ -34,6 +34,13 @@
       "range_index": true
     },
     {
+      "name": "artwork.documents_count_facet",
+      "type": "int32",
+      "facet": true,
+      "optional": true,
+      "range_index": true
+    },
+    {
       "name": "artwork.materials_facet",
       "type": "string[]",
       "facet": true,


### PR DESCRIPTION
This pull request adds a new facet for "Number of Documents" in the Artwork section. Note: The original request was to name the facet "Total Number of Documents in Artwork", but that looked a little too wordy in the facet menu.

![Screenshot 2024-12-10 at 12 21 26 PM](https://github.com/user-attachments/assets/8d6c69b4-d18c-4fea-9dbc-5e521187e5d1)
