### PR TITLE
BASIRA #273 - Copy title

### DIFF
--- a/client/src/pages/admin/Artwork.js
+++ b/client/src/pages/admin/Artwork.js
@@ -1,10 +1,11 @@
 // @flow
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { BooleanIcon, EditModal, EmbeddedList } from '@performant-software/semantic-components';
 import { Card, Form, Header } from 'semantic-ui-react';
 import _ from 'underscore';
 import ArtworkTitleModal from '../../components/ArtworkTitleModal';
+import ArtworkTitle from '../../transforms/ArtworkTitle';
 import ArtworksService from '../../services/Artworks';
 import AttachmentModal from '../../components/AttachmentModal';
 import Authorization from '../../utils/Authorization';
@@ -182,6 +183,7 @@ const Artwork = (props: Props) => {
               required: ['title']
             }
           }}
+          onCopy={ArtworkTitle.toCopy.bind(this)}
           onDelete={props.onDeleteChildAssociation.bind(this, 'artwork_titles')}
           onDrag={(dragIndex, hoverIndex) => {
             const items = [...props.item.artwork_titles];

--- a/client/src/transforms/ArtworkTitle.js
+++ b/client/src/transforms/ArtworkTitle.js
@@ -1,0 +1,27 @@
+// @flow
+
+import type { ArtworkTitle as ArtworkTitleType } from '../types/ArtworkTitle';
+import _ from 'underscore';
+import uuid from 'react-uuid';
+
+class ArtworkTitle {
+  /**
+   * Returns a copy of the passed artwork_title with any ID values removed. This function also generates a new
+   * UUID value.
+   *
+   * @param title
+   *
+   * @returns {*&{qualifications: *}}
+   */
+  toCopy(title: ArtworkTitleType) {
+    return {
+      ..._.omit(title, 'id', 'uid'),
+      qualifications: _.map(title.qualifications, (qualification) => ({
+        ..._.omit(qualification, 'id', 'uid', '_destroy', 'qualifiable_id'),
+        uid: uuid()
+      }))
+    };
+  }
+}
+
+export default new ArtworkTitle();


### PR DESCRIPTION
This pull request fixes a bug with copying `artwork_title` records on the artwork edit page. The issue was that when copying the title, we're also copying the descriptor, which is a related/nested record. We were correctly removing the `id` attribute from the `artwork_title`, but not from the related `qualifications` record.