### PR TITLE
BASIRA #284 - Labels

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -32,8 +32,8 @@
     },
     "menu": {
       "artworks": "Artworks",
-      "people": "People",
-      "places": "Places",
+      "people": "Creators",
+      "places": "Repositories",
       "users": "Users",
       "valueLists": "Value Lists"
     }

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -220,7 +220,7 @@
       "foreEdgeText": "Fore-Edge Text",
       "furniture": "Furniture",
       "iconography": "Iconography",
-      "illuminationIconography": "Illumination Iconography",
+      "illuminationIconography": "Decoration Iconography",
       "identity": "Identity of Work",
       "inscriptionsOnBinding": "Inscriptions on Binding",
       "inscriptionText": "Binding Inscription Text",
@@ -248,7 +248,7 @@
       "transcriptionDiplomatic": "Transcription: Diplomatic",
       "transcriptionExpanded": "Transcription: Expanded",
       "transcriptionTranslation": "Transcription: Translation",
-      "typeOfIllumination": "Type of Illumination",
+      "typeOfIllumination": "Type of Decoration",
       "uncutForeEdges": "Uncut Fore-Edges"
     },
     "popups": {
@@ -501,8 +501,8 @@
       "fastenings": "Fastenings",
       "foreEdgesColor": "Color of Textblock Edges",
       "furniture": "Furniture",
-      "illuminationIconography": "Illumination Iconography",
-      "illuminationType": "Type of Illumination",
+      "illuminationIconography": "Decoration Iconography",
+      "illuminationType": "Type of Decoration",
       "inscriptionsOnBinding": "Inscriptions on Binding",
       "language": "Language",
       "legibility": "Legibility",


### PR DESCRIPTION
This pull request makes some adjustments to labels:

#### Changes “Type of Illumination” to “Type of Decoration” 
both in facet groups on search UI, and in CMS, under document > “Internal Features”

#### Change “Illumination Iconography” to “Decoration Iconography”
both in facet groups on search UI, and in CMS, under document > “Internal Features”

![Screenshot 2024-12-18 at 3 24 32 PM](https://github.com/user-attachments/assets/236a356e-49fd-4b6b-8264-4e053e16e9b8)
![Screenshot 2024-12-18 at 3 24 40 PM](https://github.com/user-attachments/assets/148253be-3c03-48b8-82db-495297f291db)
![Screenshot 2024-12-18 at 3 24 49 PM](https://github.com/user-attachments/assets/6501abcf-afe5-4ffd-b6bd-1cadd7f1f17c)

#### Change “People” to “Creators” in CMS main navigation
#### Change “Place” to “Repositories” in CMS main navigation

![Screenshot 2024-12-18 at 3 25 57 PM](https://github.com/user-attachments/assets/6b3abd10-9517-4dcf-8b0c-961c22580f11)
