### PR TITLE
BASIRA #285 - ID Prefix

### DIFF
--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -220,6 +220,7 @@
       "foreEdgeText": "Fore-Edge Text",
       "furniture": "Furniture",
       "iconography": "Iconography",
+      "id": "Documents/{{id}}",
       "illuminationIconography": "Illumination Iconography",
       "identity": "Identity of Work",
       "inscriptionsOnBinding": "Inscriptions on Binding",

--- a/client/src/pages/Document.js
+++ b/client/src/pages/Document.js
@@ -41,7 +41,8 @@ const Document = () => {
           <AttributesGrid
             attributes={[{
               name: 'id',
-              label: t('Common.labels.id')
+              label: t('Common.labels.id'),
+              renderValue: () => t('Document.labels.id', { id: item.id })
             }, {
               name: 'name',
               label: t('Document.labels.name')


### PR DESCRIPTION
This pull request adds the "Documents/" prefix to the ID field value on the document detail page.

![Screenshot 2024-12-18 at 3 35 50 PM](https://github.com/user-attachments/assets/754cc89f-dfa5-46f6-a5e3-aa619c1dac93)
