### PR TITLE
BASIRA #291 - Session search history

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -14,6 +14,7 @@ import PhysicalComponent from './pages/PhysicalComponent';
 import Place from './pages/Place';
 import Search from './pages/Search';
 import SearchContextProvider from './components/SearchContextProvider';
+import SearchHistory from './pages/SearchHistory';
 import VisualContext from './pages/VisualContext';
 import './App.css';
 
@@ -23,6 +24,11 @@ const App = () => (
       <Route
         path='/'
         component={Search}
+        exact
+      />
+      <Route
+        path='/search_history'
+        component={SearchHistory}
         exact
       />
       <Route

--- a/client/src/components/NavBar.css
+++ b/client/src/components/NavBar.css
@@ -1,0 +1,3 @@
+.nav-bar.ui.menu {
+  border-radius: 0;
+}

--- a/client/src/components/NavBar.js
+++ b/client/src/components/NavBar.js
@@ -1,0 +1,28 @@
+// @flow
+
+import React from 'react';
+import { Header, Menu } from 'semantic-ui-react';
+import LinksMenu from './LinksMenu';
+import './NavBar.css';
+
+const NavBar = () => {
+  return (
+    <Menu
+      className='nav-bar'
+      inverted
+      size='large'
+    >
+      <Menu.Item>
+        <Header
+          content='BASIRA'
+          inverted
+        />
+      </Menu.Item>
+      <LinksMenu
+        position='right'
+      />
+    </Menu>
+  );
+};
+
+export default NavBar;

--- a/client/src/components/RecordPage.js
+++ b/client/src/components/RecordPage.js
@@ -80,7 +80,9 @@ const RecordPage = (props: Props) => {
           <Menu.Item
             position='right'
           >
-            <SearchLink />
+            <SearchLink
+              inverted
+            />
           </Menu.Item>
         </Menu>
       </Ref>

--- a/client/src/components/SearchFacets.js
+++ b/client/src/components/SearchFacets.js
@@ -8,11 +8,7 @@ import {
 } from '@performant-software/semantic-components';
 import React, { useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  useRange,
-  useRefinementList,
-  useToggleRefinement
-} from 'react-instantsearch-hooks-web';
+import { useRange, useRefinementList, useToggleRefinement } from 'react-instantsearch-hooks-web';
 import { Header, Segment } from 'semantic-ui-react';
 import _ from 'underscore';
 import useFacetLabels from '../hooks/FacetLabels';

--- a/client/src/components/SearchHistory.js
+++ b/client/src/components/SearchHistory.js
@@ -1,0 +1,45 @@
+// @flow
+
+import { useCallback, useEffect, useMemo } from 'react';
+import { useCurrentRefinements, useSearchBox } from 'react-instantsearch-hooks-web';
+import { useLocation } from 'react-router-dom';
+import _ from 'underscore';
+import SearchHistoryService from '../services/SearchHistory';
+import useFacetLabels from '../hooks/FacetLabels';
+
+const SearchHistory = () => {
+  const currentRefinements = useCurrentRefinements();
+  const { query } = useSearchBox();
+
+  const location = useLocation();
+  const { getLabel } = useFacetLabels();
+
+  const { search: url } = location;
+
+  /**
+   * Retrieves the label and facet value from the current refinements.
+   *
+   * @type {function(*): *}
+   */
+  const transformItem = useCallback((item) => (
+    _.map(item.refinements, (r) => `${getLabel(r.attribute)}: ${r.label}`)
+  ), [getLabel]);
+
+  /**
+   * Transforms the list of items into an array of label/values.
+   */
+  const items = useMemo(() => _.flatten(_.map(currentRefinements.items, transformItem)), [currentRefinements]);
+
+  /**
+   * Saves the search whenever the URL is changed.
+   */
+  useEffect(() => {
+    if (!(_.isEmpty(query) && _.isEmpty(items))) {
+      SearchHistoryService.saveSearch({ url, query, items, created: Date.now() });
+    }
+  }, [location.search]);
+
+  return null;
+};
+
+export default SearchHistory;

--- a/client/src/components/SearchLink.js
+++ b/client/src/components/SearchLink.js
@@ -6,7 +6,11 @@ import { Link } from 'react-router-dom';
 import { Button } from 'semantic-ui-react';
 import SearchContext from '../context/Search';
 
-const SearchLink = () => {
+type Props = {
+  inverted?: boolean
+};
+
+const SearchLink = (props: Props) => {
   const { search } = useContext(SearchContext);
   const { t } = useTranslation();
 
@@ -16,7 +20,7 @@ const SearchLink = () => {
       basic
       content={t('SearchLink.buttons.back')}
       icon='arrow alternate circle left outline'
-      inverted
+      inverted={props.inverted}
       to={`/${search || ''}`}
     />
   );

--- a/client/src/i18n/en.json
+++ b/client/src/i18n/en.json
@@ -531,6 +531,9 @@
         "subjectCulturalContext": "Subject Cultural Context"
       }
     },
+    "labels": {
+      "viewRecent": "View Recent"
+    },
     "sort": {
       "artworkDate": {
         "label": "Artwork Date",
@@ -551,6 +554,19 @@
     "buttons": {
       "collapse": "Collapse All",
       "expand": "Expand All"
+    }
+  },
+  "SearchHistory": {
+    "buttons": {
+      "clear": "Clear"
+    },
+    "columns": {
+      "created": "Created",
+      "facets": "Facets",
+      "query": "Query"
+    },
+    "messages": {
+      "copy": "Copied URL to clipboard"
     }
   },
   "SearchLink": {

--- a/client/src/pages/Search.css
+++ b/client/src/pages/Search.css
@@ -1,7 +1,3 @@
-.search > .ui.menu {
-  border-radius: 0;
-}
-
 .search .item-collection {
   padding-bottom: 1em;
 }
@@ -21,6 +17,6 @@
 
 .search .stats-container {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   margin-top: 0.5em;
 }

--- a/client/src/pages/Search.js
+++ b/client/src/pages/Search.js
@@ -25,21 +25,17 @@ import {
   useStats
 } from 'react-instantsearch-hooks-web';
 import { Link, useHistory, useLocation } from 'react-router-dom';
-import {
-  Container,
-  Grid,
-  Header,
-  Menu
-} from 'semantic-ui-react';
+import { Container, Grid } from 'semantic-ui-react';
 import _ from 'underscore';
 import Banner from '../components/Banner';
-import LinksMenu from '../components/LinksMenu';
+import NavBar from '../components/NavBar';
 import PageFooter from '../components/PageFooter';
 import SearchContext from '../context/Search';
 import SearchFacets from '../components/SearchFacets';
 import SearchResultDescription from '../components/SearchResultDescription';
 import SearchThumbnail from '../components/SearchThumbnail';
 import searchClient from '../config/Search';
+import SearchHistory from '../components/SearchHistory';
 import useFacetLabels from '../hooks/FacetLabels';
 import './Search.css';
 
@@ -58,7 +54,7 @@ const Search = () => {
    */
   const transformCurrentFacets = useCallback((items) => (
     _.map(items, (item) => ({ ...item, label: getLabel(item.label) }))
-  ), []);
+  ), [getLabel]);
 
   /**
    * Set the search in the context when the location.search attribute changes.
@@ -70,20 +66,7 @@ const Search = () => {
       className='search'
       fluid
     >
-      <Menu
-        inverted
-        size='large'
-      >
-        <Menu.Item>
-          <Header
-            content='BASIRA'
-            inverted
-          />
-        </Menu.Item>
-        <LinksMenu
-          position='right'
-        />
-      </Menu>
+      <NavBar />
       <Banner />
       <InstantSearch
         indexName={process.env.REACT_APP_TYPESENSE_COLLECTION_NAME}
@@ -97,6 +80,7 @@ const Search = () => {
         }}
         searchClient={searchClient}
       >
+        <SearchHistory />
         <Container>
           <Grid
             relaxed
@@ -113,6 +97,11 @@ const Search = () => {
                 <div
                   className='stats-container'
                 >
+                  <Link
+                    to='search_history'
+                  >
+                    { t('Search.labels.viewRecent') }
+                  </Link>
                   <SearchStats
                     useStats={useStats}
                   />

--- a/client/src/pages/SearchHistory.css
+++ b/client/src/pages/SearchHistory.css
@@ -1,0 +1,3 @@
+.search-history > .ui.container > .search-list > .table > tbody > tr > td:first-child {
+  white-space: nowrap;
+}

--- a/client/src/pages/SearchHistory.js
+++ b/client/src/pages/SearchHistory.js
@@ -1,0 +1,122 @@
+// @flow
+
+import { CurrentFacetLabels, EmbeddedList } from '@performant-software/semantic-components';
+import { useTimer } from '@performant-software/shared-components';
+import React, { useCallback, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Button, Container, Popup } from 'semantic-ui-react';
+import _ from 'underscore';
+import { getDateTimeView } from '../utils/Date';
+import NavBar from '../components/NavBar';
+import SearchHistoryService from '../services/SearchHistory';
+import SearchLink from '../components/SearchLink';
+import './SearchHistory.css';
+
+const TOOLTIP_DELAY_MS  = 1500;
+
+const SearchHistory = () => {
+  const [items, setItems] = useState(_.sortBy(SearchHistoryService.getHistory(), 'created').reverse());
+  const [copyItem, setCopyItem] = useState();
+
+  const { t } = useTranslation();
+  const { clearTimer, setTimer } = useTimer();
+
+  /**
+   * Clears the search history.
+   *
+   * @type {(function(): void)|*}
+   */
+  const onClear = useCallback(() => {
+    // Clear the items on the state
+    setItems([]);
+
+    // Clear the items in session storage
+    SearchHistoryService.clearHistory();
+  }, []);
+
+  /**
+   * Copies the URL for the passed item and sets the selected item on the state.
+   *
+   * @type {(function(*): void)|*}
+   */
+  const onCopy = useCallback((item) => {
+    const url = `${window.location.origin}/${item.url}`;
+    navigator.clipboard.writeText(url);
+
+    setCopyItem(item);
+
+    clearTimer();
+    setTimer(() => setCopyItem(null), TOOLTIP_DELAY_MS);
+  }, []);
+
+  return (
+    <Container
+      className='search-history'
+      fluid
+    >
+      <NavBar />
+      <Container>
+        <EmbeddedList
+          className='search-list'
+          actions={[{
+            as: Link,
+            asProps: (item) => ({
+              to: `/${item.url}`
+            }),
+            icon: 'arrow alternate circle right outline',
+            name: 'link'
+          }, {
+            name: 'copy',
+            render: (item) => (
+              <Popup
+                content={t('SearchHistory.messages.copy')}
+                hoverable
+                inverted
+                on='click'
+                onOpen={() => onCopy(item)}
+                open={copyItem === item}
+                trigger={(
+                  <Button
+                    basic
+                    icon='copy outline'
+                    size='small'
+                  />
+                )}
+              />
+            )
+          }]}
+          buttons={[{
+            render: () => <SearchLink />
+          }, {
+            color: 'red',
+            content: t('SearchHistory.buttons.clear'),
+            icon: 'trash',
+            onClick: onClear
+          }]}
+          columns={[{
+            name: 'created',
+            label: t('SearchHistory.columns.created'),
+            resolve: (item) => getDateTimeView(item.created)
+          }, {
+            name: 'query',
+            label: t('SearchHistory.columns.query')
+          }, {
+            name: 'items',
+            label: t('SearchHistory.columns.facets'),
+            render: (item) => (
+              <CurrentFacetLabels
+                items={_.map(item.items, (label) => ({ label }))}
+              />
+            )
+          }]}
+          defaultSort='created'
+          defaultSortDirection='descending'
+          items={items}
+        />
+      </Container>
+    </Container>
+  );
+};
+
+export default SearchHistory;

--- a/client/src/services/SearchHistory.js
+++ b/client/src/services/SearchHistory.js
@@ -1,0 +1,40 @@
+const SEARCH_HISTORY_KEY = 'basira_search_history';
+
+/**
+ * Clears the search history from session storage.
+ */
+const clearHistory = () => sessionStorage.removeItem(SEARCH_HISTORY_KEY);
+
+/**
+ * Returns the search history from session storage.
+ *
+ * @returns {any}
+ */
+const getHistory = () => JSON.parse(sessionStorage.getItem(SEARCH_HISTORY_KEY) || '[]');
+
+/**
+ * Saves the passed search history to session storage.
+ *
+ * @param url
+ * @param query
+ * @param items
+ * @param created
+ */
+const saveSearch = ({ url, query, items, created }) => {
+  const history = getHistory();
+
+  history.push({
+    url,
+    query,
+    items,
+    created
+  });
+
+  sessionStorage.setItem(SEARCH_HISTORY_KEY, JSON.stringify(history));
+};
+
+export default {
+  clearHistory,
+  getHistory,
+  saveSearch
+};


### PR DESCRIPTION
This pull request adds the ability to view/clear the search history for a user's browser session. There is now a "View Recent" link under the search box which will bring the user to a page containing a list of the recent searches (in descending order by timestamp).

![Screenshot 2024-12-23 at 7 52 45 PM](https://github.com/user-attachments/assets/9433a0fc-cf99-48a2-bcb1-0f963bde7d3a)
![Screenshot 2024-12-23 at 7 54 18 PM](https://github.com/user-attachments/assets/4aeb7ab6-daa4-4879-8997-60580325986a)
