### PR TITLE
BASIRA #293 - Image file names

### DIFF
--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -23,4 +23,7 @@ class Artwork < ApplicationRecord
                :published, :repository_work_url, :accession_number, :number_documents_visible, images: [],
                 artwork_titles_attributes: [:id, :title, :notes, :primary, :_destroy,
                 qualifications_attributes: [:id, :value_list_id, :notes, :persistent, :_destroy]]
+
+  # Attachable methods
+  allow_multiple true
 end

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -2,6 +2,9 @@ module Attachable
   extend ActiveSupport::Concern
 
   included do
+    # Class attributes
+    class_attribute :multiple
+
     # Relationships
     has_many :attachments, -> { order(primary: :desc) }, as: :attachable, dependent: :destroy
     has_one :primary_attachment, -> { where(primary: true) }, as: :attachable, class_name: 'Attachment'
@@ -13,9 +16,42 @@ module Attachable
     allow_params attachments_attributes: [:id, :file, :primary, :_destroy, qualifications_attributes: [
       :id, :qualifiable_id, :qualifiable_type, :value_list_id, :form_field, :notes, :persistent, :_destroy]
     ]
+
+    # Actions
+    after_save :rename_attachments
+
+    private
+
+    def generate_filename(attachment, index)
+      filename = "#{self.class.to_s}#{self.id}"
+      filename += "-#{index}" if self.class.multiple
+      filename += ".#{attachment.file.filename.extension}"
+
+      filename
+    end
+
+    def rename_attachments
+      self.attachments.order(:created_at).each.with_index do |attachment, index|
+        # Generate the filename
+        filename = generate_filename(attachment, index + 1)
+
+        # Update the attachment filename
+        attachment.file.blob.update(filename: filename) unless attachment.file.blob.filename == filename
+
+        # Update variant file names
+        attachment.file.variant_records.each do |variant|
+          next unless variant.blob.filename != filename
+          variant.blob.update(filename: filename)
+        end
+      end
+    end
   end
 
   class_methods do
+    def allow_multiple(multiple)
+      self.multiple = multiple
+    end
+
     def attachments_preload
       { attachments: [file_attachment: :blob] }
     end

--- a/db/data/20241224164957_rename_image_attachments.rb
+++ b/db/data/20241224164957_rename_image_attachments.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+class RenameImageAttachments < ActiveRecord::Migration[7.0]
+  def up
+    # Update documents
+    execute <<-SQL.squish
+      WITH 
+      update_documents AS (
+        SELECT active_storage_blobs.id AS blob_id,
+               'Document' || documents.id || '.' || SPLIT_PART(active_storage_blobs.filename, '.', -1) AS filename
+          FROM documents
+          JOIN attachments ON attachments.attachable_id = documents.id
+                          AND attachments.attachable_type = 'Document'
+          JOIN active_storage_attachments ON active_storage_attachments.record_id = attachments.id
+                                         AND active_storage_attachments.record_type = 'Attachment'
+                                         AND active_storage_attachments.name = 'file'
+          JOIN active_storage_blobs ON active_storage_blobs.id = active_storage_attachments.blob_id
+      )
+      UPDATE active_storage_blobs
+         SET filename = update_documents.filename
+        FROM update_documents
+       WHERE update_documents.blob_id = active_storage_blobs.id
+    SQL
+
+    # Update visual contexts
+    execute <<-SQL.squish
+      WITH 
+      update_visual_contexts AS (
+        SELECT active_storage_blobs.id AS blob_id,
+               'VisualContext' || visual_contexts.id || '.' || SPLIT_PART(active_storage_blobs.filename, '.', -1) AS filename
+          FROM visual_contexts
+          JOIN attachments ON attachments.attachable_id = visual_contexts.id
+                          AND attachments.attachable_type = 'VisualContext'
+          JOIN active_storage_attachments ON active_storage_attachments.record_id = attachments.id
+                                         AND active_storage_attachments.record_type = 'Attachment'
+                                         AND active_storage_attachments.name = 'file'
+          JOIN active_storage_blobs ON active_storage_blobs.id = active_storage_attachments.blob_id
+      )
+      UPDATE active_storage_blobs
+         SET filename = update_visual_contexts.filename
+        FROM update_visual_contexts
+       WHERE update_visual_contexts.blob_id = active_storage_blobs.id
+    SQL
+
+    # Update physical components
+    execute <<-SQL.squish
+      WITH 
+      update_physical_components AS (
+        SELECT active_storage_blobs.id AS blob_id,
+               'PhysicalComponent' || physical_components.id || '.' || SPLIT_PART(active_storage_blobs.filename, '.', -1) AS filename
+          FROM physical_components
+          JOIN attachments ON attachments.attachable_id = physical_components.id
+                          AND attachments.attachable_type = 'PhysicalComponent'
+          JOIN active_storage_attachments ON active_storage_attachments.record_id = attachments.id
+                                         AND active_storage_attachments.record_type = 'Attachment'
+                                         AND active_storage_attachments.name = 'file'
+          JOIN active_storage_blobs ON active_storage_blobs.id = active_storage_attachments.blob_id
+      )
+      UPDATE active_storage_blobs
+         SET filename = update_physical_components.filename
+        FROM update_physical_components
+       WHERE update_physical_components.blob_id = active_storage_blobs.id
+    SQL
+
+    # Update artworks
+    execute <<-SQL.squish
+      WITH 
+      update_artworks AS (
+        SELECT active_storage_blobs.id AS blob_id,
+               'Artwork' || artworks.id || '-' || row_number() OVER (PARTITION BY artworks.id) || '.' || SPLIT_PART(active_storage_blobs.filename, '.', -1) AS filename
+          FROM artworks
+          JOIN attachments ON attachments.attachable_id = artworks.id
+                          AND attachments.attachable_type = 'Artwork'
+          JOIN active_storage_attachments ON active_storage_attachments.record_id = attachments.id
+                                         AND active_storage_attachments.record_type = 'Attachment'
+                                         AND active_storage_attachments.name = 'file'
+          JOIN active_storage_blobs ON active_storage_blobs.id = active_storage_attachments.blob_id
+      )
+      UPDATE active_storage_blobs
+         SET filename = update_artworks.filename
+        FROM update_artworks
+       WHERE update_artworks.blob_id = active_storage_blobs.id
+    SQL
+
+    # Update variants
+    execute <<-SQL.squish
+      WITH
+      update_variants AS (
+        SELECT variant_blobs.id AS blob_id, active_storage_blobs.filename AS filename
+          FROM active_storage_blobs
+          JOIN active_storage_variant_records ON active_storage_variant_records.blob_id = active_storage_blobs.id
+          JOIN active_storage_attachments ON active_storage_attachments.record_id = active_storage_variant_records.id
+                                         AND active_storage_attachments.record_type = 'ActiveStorage::VariantRecord'
+          JOIN active_storage_blobs variant_blobs ON variant_blobs.id = active_storage_attachments.blob_id
+      )
+      UPDATE active_storage_blobs
+         SET filename = update_variants.filename
+        FROM update_variants
+       WHERE update_variants.blob_id = active_storage_blobs.id
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20241211173335)
+DataMigrate::Data.define(version: 20241224164957)


### PR DESCRIPTION
This pull request adds automatic file renaming to `documents`, `visual_contexts`, `physical_components`, and `artworks` image records. The file naming convention will use the following rules:

## Documents, Visual Contexts, Physical Components
These records only allow a single image per record.

```
<Model><ID>.<extension>
Document123.jpg
VisualContext42.jpg
PhysicalComponent9.jpg
```

## Artworks
These records allow multiple images per record

```
<Model><ID>-<Index>.<extension>
Artwork123-1.jpg
Artwork123-2.jpg
...
Artwork123-47.jpg
Artwork124.jpg
```