### PR TITLE
Fix onSearch bug in location modal (#302)

### DIFF
--- a/client/src/components/LocationModal.js
+++ b/client/src/components/LocationModal.js
@@ -36,7 +36,7 @@ const LocationModal = (props: Props) => {
    *
    * @type {function(): function(*): *}
    */
-  const onSearch = useCallback(() => (search) => Places.fetchAll({ search, sort_by: 'name' }), []);
+  const onSearch = useCallback((search) => Places.fetchAll({ search, sort_by: 'name' }), []);
 
   return (
     <Modal


### PR DESCRIPTION
## In this PR

Per #302:
- Fixes a bug that, when adding a location to an Artwork or Person, prevented searching and selecting the location via the dropdown