### PR TITLE
Use icon instead of button for tooltip (#304)

### DIFF
--- a/client/src/components/SearchFacet.css
+++ b/client/src/components/SearchFacet.css
@@ -6,10 +6,12 @@
 }
 
 .search-facet.facet-list .facet-label > .label {
+  display: flex;
+  align-items: center;
   padding-right: 1em;
 }
 
 .search-facet.facet-list .facet-label .info-button {
   margin-left: 0.5em;
-  padding: 0.5em;
+  color: #000000ab !important;
 }

--- a/client/src/components/SearchFacet.js
+++ b/client/src/components/SearchFacet.js
@@ -8,7 +8,7 @@ import React, {
   useState
 } from 'react';
 import { useRefinementList } from 'react-instantsearch-hooks-web';
-import { Button, Popup } from 'semantic-ui-react';
+import { Icon, Popup } from 'semantic-ui-react';
 import _ from 'underscore';
 import ValueLists from '../services/ValueLists';
 import './SearchFacet.css';
@@ -91,12 +91,11 @@ const SearchFacet = forwardRef((props: Props, ref: HTMLElement) => {
               mouseLeaveDelay={500}
               on='hover'
               trigger={(
-                <Button
-                  basic
+                <Icon
                   className='info-button'
                   circular
-                  size='mini'
-                  icon='info'
+                  size='small'
+                  name='info'
                 />
               )}
             />


### PR DESCRIPTION
## In this PR

Per #304:
- Change tooltip trigger to `Icon` as `Button` was interfering with `label` element clicks
   - Interactive elements like `button` inside a `label` are disallowed by the HTML spec, so browsers treat them inconsistently

