### PR TITLE
Show Back to Search unless NOT from search (#305)

### DIFF
--- a/client/src/components/ListPage.js
+++ b/client/src/components/ListPage.js
@@ -29,7 +29,12 @@ const ListPage = (props: Props) => {
           actions={[{
             as: Link,
             asProps: (item) => ({
-              to: `${location.pathname}/${item.id}`
+              to: {
+                pathname: `${location.pathname}/${item.id}`,
+                state: {
+                  fromList: true,
+                }
+              }
             }),
             name: 'navigate',
             icon: 'arrow alternate circle right outline',

--- a/client/src/components/RecordPage.js
+++ b/client/src/components/RecordPage.js
@@ -43,7 +43,7 @@ const RecordPage = (props: Props) => {
   const menuBarRef = useRef(null);
   const { height: minHeight } = useSidebar(menuBarRef);
 
-  const { state: { fromSearch } = {} } = location;
+  const { state: { fromList } = {} } = location;
 
   return (
     <Container
@@ -81,7 +81,7 @@ const RecordPage = (props: Props) => {
               { props.renderTitle() }
             </Menu.Item>
           )}
-          { fromSearch && (
+          { !fromList && (
             <Menu.Item
               position='right'
             >

--- a/client/src/pages/Search.js
+++ b/client/src/pages/Search.js
@@ -177,14 +177,7 @@ const Search = () => {
               >
                 <SearchResults
                   as={Link}
-                  asProps={(document) => ({
-                    to: {
-                      pathname: `/documents/${document.id}`,
-                      state: {
-                        fromSearch: true
-                      }
-                    }
-                  })}
+                  asProps={(document) => ({ to: `/documents/${document.id}` })}
                   link
                   renderDescription={(document) => document.artwork.date_descriptor}
                   renderEmptyList={() => null}


### PR DESCRIPTION
## In this PR

Per #305:
- Use `fromList` state when accessing a Person or Place from the lists; if not `fromList`, always show "Back to Search" button

Basically the users wanted to see this "Back to Search" button after many intermediate clicks after search. Rather than try to keep track of this and determine the complex route someone might take from search to a specific detail page, I decided to just always assume they accessed it from search unless they _specifically_ accessed it from elsewhere. 

Currently the only way to access records otherwise is from the list pages, besides just being given a link to an individual record (at which point I think it's fine to show the "back to search" button anyway), so I just conditionally hide the "back to search" button if they came from a list page.