### PR TITLE
Use Label.Group for group of labels (#308)

### DIFF
--- a/client/src/components/DocumentActions.js
+++ b/client/src/components/DocumentActions.js
@@ -59,8 +59,7 @@ const DocumentActions = (props: Props) => {
           key={index}
         >
           <Card.Content>
-            <Card.Header
-            >
+            <Card.Header>
               <Header
                 content={renderActionText(item)}
                 size='tiny'
@@ -75,8 +74,10 @@ const DocumentActions = (props: Props) => {
           <Card.Content
             extra
           >
-            { renderDescriptors(item, 'Characteristic', 'blue') }
-            { renderDescriptors(item, 'Body', 'green') }
+            <Label.Group>
+              { renderDescriptors(item, 'Characteristic', 'blue') }
+              { renderDescriptors(item, 'Body', 'green') }
+            </Label.Group>
           </Card.Content>
         </Card>
       ))}


### PR DESCRIPTION
## In this PR

Per #308:
- Use semantic-ui-react `Label.Group` to group labels in `DocumentActions`

Before:

![Screenshot 2025-02-20 at 3 56 54 PM](https://github.com/user-attachments/assets/267ce4b0-12cf-49ab-b975-fbb38adff4f6)

After:

![Screenshot 2025-02-20 at 3 56 37 PM](https://github.com/user-attachments/assets/dcc5b8db-aebb-4db9-91b9-6e24d8b7268a)

