### PR TITLE
Remove stale Qualification ID in duplicated ValueList record (#311)

### DIFF
--- a/client/src/components/ValueListsTable.js
+++ b/client/src/components/ValueListsTable.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { ListTable, useDataList } from '@performant-software/semantic-components';
+import { ObjectJs as ObjectUtils } from '@performant-software/shared-components';
 import type { EditContainerProps } from '@performant-software/shared-components/types';
 import React from 'react';
 import { withTranslation } from 'react-i18next';
@@ -60,6 +61,8 @@ const ValueListsTable = (props: Props) => (
         required: ['object', 'group', 'human_name']
       }
     }}
+    // on copy, strip both ValueList id and any Qualifications id
+    onCopy={(item) => ObjectUtils.without(item, 'id')}
     onDelete={(params) => ValueListsService.delete(params)}
     onLoad={(params) => ValueListsService.fetchAll({
       ...params,

--- a/client/src/transforms/ValueList.js
+++ b/client/src/transforms/ValueList.js
@@ -3,6 +3,7 @@
 import _ from 'underscore';
 import BaseTransform from './BaseTransform';
 import Qualifications from './Qualifications';
+import { ObjectJs as ObjectUtils } from '@performant-software/shared-components';
 
 import type { ValueList as ValueListType } from '../types/ValueList';
 
@@ -58,11 +59,12 @@ class ValueList extends BaseTransform {
    * @returns {*}
    */
   toPayload(valueList: ValueListType) {
+    let qualificationsPayload = Qualifications.toPayload(valueList);
     // if duplicating a ValueList record, Qualifications payload will include IDs
     // of original record's Qualifications. remove IDs so we can create new ones
-    const qualificationsPayload = Qualifications.toPayload(valueList);
-    // eslint-disable-next-line no-param-reassign
-    qualificationsPayload.qualifications?.forEach((q) => { delete q.id; });
+    if (!valueList.id) {
+      qualificationsPayload = ObjectUtils.without(qualificationsPayload, 'id');
+    }
     return {
         value_list: {
           ..._.pick(valueList, this.PAYLOAD_KEYS),

--- a/client/src/transforms/ValueList.js
+++ b/client/src/transforms/ValueList.js
@@ -58,11 +58,17 @@ class ValueList extends BaseTransform {
    * @returns {*}
    */
   toPayload(valueList: ValueListType) {
+    // if duplicating a ValueList record, Qualifications payload will include IDs
+    // of original record's Qualifications. remove IDs so we can create new ones
+    const qualificationsPayload = Qualifications.toPayload(valueList);
+    // eslint-disable-next-line no-param-reassign
+    qualificationsPayload.qualifications?.forEach((q) => { delete q.id; });
     return {
-      value_list: {
-        ..._.pick(valueList, this.PAYLOAD_KEYS),
-        ...Qualifications.toPayload(valueList)
-    }};
+        value_list: {
+          ..._.pick(valueList, this.PAYLOAD_KEYS),
+          ...qualificationsPayload
+      }
+    };
   }
 }
 

--- a/client/src/transforms/ValueList.js
+++ b/client/src/transforms/ValueList.js
@@ -3,7 +3,6 @@
 import _ from 'underscore';
 import BaseTransform from './BaseTransform';
 import Qualifications from './Qualifications';
-import { ObjectJs as ObjectUtils } from '@performant-software/shared-components';
 
 import type { ValueList as ValueListType } from '../types/ValueList';
 
@@ -59,16 +58,10 @@ class ValueList extends BaseTransform {
    * @returns {*}
    */
   toPayload(valueList: ValueListType) {
-    let qualificationsPayload = Qualifications.toPayload(valueList);
-    // if duplicating a ValueList record, Qualifications payload will include IDs
-    // of original record's Qualifications. remove IDs so we can create new ones
-    if (!valueList.id) {
-      qualificationsPayload = ObjectUtils.without(qualificationsPayload, 'id');
-    }
     return {
         value_list: {
           ..._.pick(valueList, this.PAYLOAD_KEYS),
-          ...qualificationsPayload
+          ...Qualifications.toPayload(valueList)
       }
     };
   }


### PR DESCRIPTION
## In this PR

Per #311:
- When a `ValueList` record with a `Qualifications` association was duplicated, the `Qualifications` association's id would carry along with the rest of the duplicate data, resulting in an error when the DB tried to match that old id to the new `ValueList` record. This PR removes that id from the nested association when `valueList.id` does not exist, in other words, when it's a new `valueList`.