### PR TITLE
BASIRA #320 - Value lists

### DIFF
--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -6,4 +6,15 @@ class Qualification < ApplicationRecord
   # Delegates
   delegate :group, to: :value_list, prefix: true
   delegate :object, to: :value_list, prefix: true
+
+  # Validations
+  validate :validate_value_list
+
+  private
+
+  def validate_value_list
+    if value_list_id == qualifiable_id && qualifiable_type == ValueList.to_s
+      errors.add(:value_list_id, I18n.t('errors.qualification.self_reference'))
+    end
+  end
 end

--- a/client/src/components/ValueListModal.js
+++ b/client/src/components/ValueListModal.js
@@ -50,12 +50,14 @@ const ValueListModal = (props: Props) => (
         required={props.isRequired('human_name')}
         value={props.item.human_name || ''}
       />
-      <ValueListDropdown
-        {...props}
-        group='Authorized Vocabulary'
-        label={props.t('ValueList.labels.authorizedVocabulary')}
-        object='General'
-      />
+      { props.item.group !== 'Authorized Vocabulary' && (
+        <ValueListDropdown
+          {...props}
+          group='Authorized Vocabulary'
+          label={props.t('ValueList.labels.authorizedVocabulary')}
+          object='General'
+        />
+      )}
       <Form.Input
         error={props.isError('authorized_vocabulary_url')}
         label={props.t('ValueList.labels.authorizedVocabularyUrl')}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,4 +31,8 @@
 
 en:
   errors:
+
+    qualification:
+      self_reference: "can't reference self"
+
     unauthorized: "Unauthorized"


### PR DESCRIPTION
This pull request adds a validation rule to `qualifications` to ensure that value lists cannot be related to themselves via the Authorized Vocabulary field. It also hides the Authorized Vocabulary field for any `value_list` record in the"Authorized Vocabulary" group.

## Authorized Vocabulary field visible
![Screenshot 2025-04-03 at 6 38 21 AM](https://github.com/user-attachments/assets/c0e17bbd-defa-4e02-891c-6f8578958f79)

## Authorized Vocabulary field hidden
![Screenshot 2025-04-03 at 6 38 40 AM](https://github.com/user-attachments/assets/64838e76-be59-4b40-bb5c-09092438cc7f)
