### PR TITLE
BASIRA #324 - Binding color

### DIFF
--- a/client/src/pages/Document.js
+++ b/client/src/pages/Document.js
@@ -127,7 +127,8 @@ const Document = () => {
                 label: t('Document.labels.bindingColor'),
                 qualification: {
                   object: 'Document',
-                  group: 'Binding Color'
+                  group: 'Color',
+                  formField: 'binding_color'
                 }
               }, {
                 name: 'number_sewing_supports',


### PR DESCRIPTION
This pull request fixes an issue with the "Binding Color" field not displaying on the document detail page. The issue was that the `group` attribute was incorrect and the `formField` attribute was not provided.

![Screenshot 2025-06-16 at 11 30 10 AM](https://github.com/user-attachments/assets/1e6b9b19-a6f2-422d-81e4-a7a4be8765c4)
