### PR TITLE
BASIRA #326 - Search history

### DIFF
--- a/client/src/components/SearchHistory.js
+++ b/client/src/components/SearchHistory.js
@@ -1,11 +1,17 @@
 // @flow
 
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useCurrentRefinements, useSearchBox } from 'react-instantsearch-hooks-web';
 import { useLocation } from 'react-router-dom';
 import _ from 'underscore';
 import SearchHistoryService from '../services/SearchHistory';
 import useFacetLabels from '../hooks/FacetLabels';
+
+const LoadStatus = {
+  initial: 0,
+  firstRender: 1,
+  rendered: 2
+};
 
 const SearchHistory = () => {
   const currentRefinements = useCurrentRefinements();
@@ -15,6 +21,10 @@ const SearchHistory = () => {
   const { getLabel } = useFacetLabels();
 
   const { search: url } = location;
+
+  const loadState = useRef({
+    status: LoadStatus.initial
+  });
 
   /**
    * Retrieves the label and facet value from the current refinements.
@@ -31,13 +41,60 @@ const SearchHistory = () => {
   const items = useMemo(() => _.flatten(_.map(currentRefinements.items, transformItem)), [currentRefinements]);
 
   /**
-   * Saves the search whenever the URL is changed.
+   * On initial render, we may need to wait for the query and refinements to be loaded into the state before
+   * pushing into the search history.
    */
   useEffect(() => {
-    if (!(_.isEmpty(query) && _.isEmpty(items))) {
+    const { hasQuery, hasRefinements, status } = loadState.current
+
+    if (status === LoadStatus.firstRender) {
+      if ((hasQuery && !_.isEmpty(query) || (hasRefinements && !_.isEmpty(items)))) {
+        SearchHistoryService.saveSearch({ url, query, items, created: Date.now() });
+
+        loadState.current = {
+          status: LoadStatus.rendered
+        };
+      }
+
+      if (!(hasQuery || hasRefinements)) {
+        loadState.current = {
+          status: LoadStatus.rendered
+        };
+      }
+    }
+  }, [query, items]);
+
+  /**
+   * After the initial render, use the URL to determine if we should push into the search history.
+   */
+  useEffect(() => {
+    const { status } = loadState.current;
+
+    if (status === LoadStatus.rendered && !(_.isEmpty(query) && _.isEmpty(items))) {
       SearchHistoryService.saveSearch({ url, query, items, created: Date.now() });
     }
-  }, [location.search]);
+  }, [url]);
+
+  /**
+   * On initial render, the URL is set before the query/refinements are loaded into the state. When the component
+   * is mounted, we'll keep track of whether the URL search contains a query/refinements and wait for them to
+   * be loaded into the state before pushing to the search history.
+   */
+  useEffect(() => {
+    let hasQuery = false;
+    let hasRefinements = false;
+
+    if (!_.isEmpty(url)) {
+      hasQuery = url.includes('query');
+      hasRefinements = url.includes('refinementList');
+    }
+
+    loadState.current = {
+      hasQuery,
+      hasRefinements,
+      status: LoadStatus.firstRender
+    };
+  }, []);
 
   return null;
 };


### PR DESCRIPTION
This pull request fixes a bug where the search history wasn't being accurately updated in some situations. It was due to a difference in the way the URL and query/refinements are added to the state. On a page refresh, the URL is set first, then the query/refinements loaded. On subsequent changes to the query/refinements, the query/refinement state is updated, then the URL.

The solution here was to keep track of whether we're page refresh or not, and update the state accordingly.