### PR TITLE
Fix DATABASE_NAME missing key error

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -22,6 +22,6 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%= ENV.fetch("DATABASE_TEST_NAME") { "#{ENV.fetch('DATABASE_NAME')}_test" } %>
+  database: <%= ENV.fetch("DATABASE_TEST_NAME") { 'basira_test' } %>
 production:
   <<: *default


### PR DESCRIPTION
In environments like where DATABASE_NAME is not present, as on Heroku, fetching that variable raises KeyError error. Use basira_test as the default test database name.