### PR TITLE
Fix malformed leading-bracket key in action qualifications FormData

### DIFF
--- a/client/src/transforms/Actions.js
+++ b/client/src/transforms/Actions.js
@@ -35,7 +35,7 @@ class Actions extends NestedAttributes {
         formData.append(`${prefix}[${collection}][${index}][${key}]`, String.toString(item[key]));
       });
 
-      Qualifications.appendFormData(formData, `[${prefix}][${collection}][${index}]`, item);
+      Qualifications.appendFormData(formData, `${prefix}[${collection}][${index}]`, item);
     });
   }
 }


### PR DESCRIPTION
Qualifications.appendFormData was called with an extra `[...]` wrapping the prefix, producing a stray top-level `[document]` key instead of `document[actions][0]`. Rack 2 tolerated this malformed key; Rack 3 (brought in by the Rails 7 upgrade) parses it as a separate parameter tree, so qualifications were silently stranded outside the `document` tree and never reached the server.